### PR TITLE
Replace window.location with location

### DIFF
--- a/src/components/APIViews/Search/SearchDisplay/PageNum/PaginationButton/index.js
+++ b/src/components/APIViews/Search/SearchDisplay/PageNum/PaginationButton/index.js
@@ -4,14 +4,14 @@ import { connect } from 'react-redux'
 import { Link } from 'gatsby'
 import queryString from 'query-string'
 
-export const PaginationButton = ({ currentPage, prev, searchReducer }) => {
+export const PaginationButton = ({ currentPage, prev, searchReducer, location }) => {
   const { nextpage } = searchReducer
 
   // Do not render if no nextPage on next link OR
   // Do not render if currently on 1st page and prev
   if ((!prev && nextpage) || (prev && currentPage > 1)) {
     const settings = getSettings(prev, currentPage)
-    const target = linkTarget(window.location, settings.targetPage)
+    const target = linkTarget(location, settings.targetPage)
     return (
       <Link to={target}>
         <button
@@ -27,6 +27,7 @@ PaginationButton.propTypes = {
   searchReducer: PropTypes.object.isRequired,
   prev: PropTypes.bool,
   currentPage: PropTypes.number.isRequired,
+  location: PropTypes.object,
 }
 
 export const mapStateToProps = (state) => {

--- a/src/components/APIViews/Search/SearchDisplay/PageNum/PaginationButton/index.js
+++ b/src/components/APIViews/Search/SearchDisplay/PageNum/PaginationButton/index.js
@@ -27,7 +27,7 @@ PaginationButton.propTypes = {
   searchReducer: PropTypes.object.isRequired,
   prev: PropTypes.bool,
   currentPage: PropTypes.number.isRequired,
-  location: PropTypes.object,
+  location: PropTypes.object.isRequired,
 }
 
 export const mapStateToProps = (state) => {

--- a/src/components/APIViews/Search/SearchDisplay/PageNum/index.js
+++ b/src/components/APIViews/Search/SearchDisplay/PageNum/index.js
@@ -30,7 +30,7 @@ export const mapStateToProps = (state) => {
 
 PageNum.propTypes = {
   searchReducer: PropTypes.object.isRequired,
-  location: PropTypes.object,
+  location: PropTypes.object.isRequired,
 }
 
 export default connect(mapStateToProps)(PageNum)

--- a/src/components/APIViews/Search/SearchDisplay/PageNum/index.js
+++ b/src/components/APIViews/Search/SearchDisplay/PageNum/index.js
@@ -4,15 +4,22 @@ import style from './style.module.css'
 import PropTypes from 'prop-types'
 import PaginationButton from './PaginationButton'
 
-export const PageNum = ({ searchReducer }) => {
+export const PageNum = ({ searchReducer, location }) => {
   let { page } = searchReducer
   page = parseInt(page, 10) || 1
 
   return (
     <div className={style.pagenum}>
-      <PaginationButton currentPage={page} prev />
+      <PaginationButton
+        currentPage={page}
+        location={location}
+        prev
+      />
       <div className={style.pageLink}>Page {page}</div>
-      <PaginationButton currentPage={page} />
+      <PaginationButton
+        currentPage={page}
+        location={location}
+      />
     </div>
   )
 }
@@ -23,6 +30,7 @@ export const mapStateToProps = (state) => {
 
 PageNum.propTypes = {
   searchReducer: PropTypes.object.isRequired,
+  location: PropTypes.object,
 }
 
 export default connect(mapStateToProps)(PageNum)

--- a/src/components/APIViews/Search/SearchDisplay/PerPage/index.js
+++ b/src/components/APIViews/Search/SearchDisplay/PerPage/index.js
@@ -30,7 +30,7 @@ export const PerPage = ({ searchReducer, location }) => {
 
 PerPage.propTypes = {
   searchReducer: PropTypes.object.isRequired,
-  location: PropTypes.object,
+  location: PropTypes.object.isRequired,
 }
 
 export const mapStateToProps = (state) => {

--- a/src/components/APIViews/Search/SearchDisplay/PerPage/index.js
+++ b/src/components/APIViews/Search/SearchDisplay/PerPage/index.js
@@ -14,13 +14,13 @@ const options = [
   { value: 60, label: '60/page' },
 ]
 
-export const PerPage = ({ searchReducer }) => {
+export const PerPage = ({ searchReducer, location }) => {
   let { perpage } = searchReducer
   perpage = parseInt(perpage, 10) || 12
   return (
     <Select
       options={options}
-      onChange={e => handleChange(e, window.location)}
+      onChange={e => handleChange(e, location)}
       placeholder={perpage + '/page'}
       selectedValue={perpage}
       className={style.perpage}
@@ -30,6 +30,7 @@ export const PerPage = ({ searchReducer }) => {
 
 PerPage.propTypes = {
   searchReducer: PropTypes.object.isRequired,
+  location: PropTypes.object,
 }
 
 export const mapStateToProps = (state) => {

--- a/src/components/APIViews/Search/SearchDisplay/index.js
+++ b/src/components/APIViews/Search/SearchDisplay/index.js
@@ -17,7 +17,7 @@ export const SearchDisplay = ({ location }) => {
 }
 
 SearchDisplay.propTypes = {
-  location: PropTypes.object,
+  location: PropTypes.object.isRequired,
 }
 
 export default SearchDisplay

--- a/src/components/APIViews/Search/SearchDisplay/index.js
+++ b/src/components/APIViews/Search/SearchDisplay/index.js
@@ -1,18 +1,23 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import DisplayViewToggle from 'components/Shared/DisplayViewToggle'
 import PerPage from './PerPage'
 import PageNum from './PageNum'
 import Results from './Results'
 
-export const SearchDisplay = () => {
+export const SearchDisplay = ({ location }) => {
   return (
     <DisplayViewToggle>
-      <PerPage />
-      <PageNum />
+      <PerPage location={location} />
+      <PageNum location={location} />
       <Results />
-      <PageNum />
+      <PageNum location={location} />
     </DisplayViewToggle>
   )
+}
+
+SearchDisplay.propTypes = {
+  location: PropTypes.object,
 }
 
 export default SearchDisplay

--- a/src/components/APIViews/Search/index.js
+++ b/src/components/APIViews/Search/index.js
@@ -24,7 +24,7 @@ export const Search = ({ searchReducer, location }) => {
 }
 
 Search.propTypes = {
-  location: PropTypes.object,
+  location: PropTypes.object.isRequired,
 }
 
 const mapStateToProps = (state) => {

--- a/src/components/APIViews/Search/index.js
+++ b/src/components/APIViews/Search/index.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import SearchDisplay from './SearchDisplay'
 import Loading from 'components/Shared/Loading'
-
 import {
   STATUS_SEARCH_EMPTY,
   STATUS_SEARCH_READY,
   STATUS_SEARCH_ERROR,
 } from 'store/actions/searchActions'
 
+// The location prop is only available from Gatsby in components inside the 'page' and 'template' directories and must be passed down.
 export const Search = ({ searchReducer, location }) => {
   switch (searchReducer.status) {
     case STATUS_SEARCH_EMPTY:

--- a/src/components/APIViews/Search/index.js
+++ b/src/components/APIViews/Search/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import SearchDisplay from './SearchDisplay'
 import Loading from 'components/Shared/Loading'
@@ -9,17 +10,21 @@ import {
   STATUS_SEARCH_ERROR,
 } from 'store/actions/searchActions'
 
-export const Search = ({ searchReducer }) => {
+export const Search = ({ searchReducer, location }) => {
   switch (searchReducer.status) {
     case STATUS_SEARCH_EMPTY:
       return <div>No Results Found</div>
     case STATUS_SEARCH_READY:
-      return <SearchDisplay />
+      return <SearchDisplay location={location} />
     case STATUS_SEARCH_ERROR:
       return <div>An Error Has Occurred.</div>
     default:
       return <Loading />
   }
+}
+
+Search.propTypes = {
+  location: PropTypes.object,
 }
 
 const mapStateToProps = (state) => {

--- a/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/index.js
+++ b/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/index.js
@@ -5,9 +5,9 @@ import Layout from 'components/Layout'
 import SEO from 'components/Seo'
 import style from './style.module.css'
 
-export const UniversalViewerLayout = ({ data, manifest }) => {
-  if (typeof window !== `undefined`) {
-    const qs = queryString.parse(window.location.search).manifest
+export const UniversalViewerLayout = ({ data, manifest, location }) => {
+  if (location) {
+    const qs = queryString.parse(location.search).manifest
     if (!manifest && qs) {
       manifest = qs
     }
@@ -42,6 +42,7 @@ UniversalViewerLayout.propTypes = {
     }).isRequired,
   }).isRequired,
   manifest: PropTypes.string,
+  location: PropTypes.object,
 }
 
 export default UniversalViewerLayout

--- a/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/index.js
+++ b/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/index.js
@@ -6,7 +6,7 @@ import SEO from 'components/Seo'
 import style from './style.module.css'
 
 export const UniversalViewerLayout = ({ data, manifest, location }) => {
-  if (location) {
+  if (location.search) {
     const qs = queryString.parse(location.search).manifest
     if (!manifest && qs) {
       manifest = qs
@@ -42,7 +42,7 @@ UniversalViewerLayout.propTypes = {
     }).isRequired,
   }).isRequired,
   manifest: PropTypes.string,
-  location: PropTypes.object,
+  location: PropTypes.object.isRequired,
 }
 
 export default UniversalViewerLayout

--- a/src/components/ManifestViews/UniversalViewer/index.js
+++ b/src/components/ManifestViews/UniversalViewer/index.js
@@ -3,7 +3,7 @@ import { StaticQuery, graphql } from 'gatsby'
 import PropTypes from 'prop-types'
 import UniversalViewerLayout from './UniversalViewerLayout'
 
-export const UniversalViewer = ({ manifest }) => {
+export const UniversalViewer = ({ manifest, location }) => {
   return (
     <StaticQuery
       query={graphql`
@@ -20,6 +20,7 @@ export const UniversalViewer = ({ manifest }) => {
         <UniversalViewerLayout
           data={data}
           manifest={manifest}
+          location={location}
         />
       )}
     />
@@ -27,6 +28,7 @@ export const UniversalViewer = ({ manifest }) => {
 }
 
 UniversalViewer.propTypes = {
+  location: PropTypes.object,
   manifest: PropTypes.string,
 }
 

--- a/src/components/ManifestViews/UniversalViewer/index.js
+++ b/src/components/ManifestViews/UniversalViewer/index.js
@@ -28,7 +28,7 @@ export const UniversalViewer = ({ manifest, location }) => {
 }
 
 UniversalViewer.propTypes = {
-  location: PropTypes.object,
+  location: PropTypes.object.isRequired,
   manifest: PropTypes.string,
 }
 

--- a/src/components/ManifestViews/UniversalViewer/index.js
+++ b/src/components/ManifestViews/UniversalViewer/index.js
@@ -3,6 +3,7 @@ import { StaticQuery, graphql } from 'gatsby'
 import PropTypes from 'prop-types'
 import UniversalViewerLayout from './UniversalViewerLayout'
 
+// The location prop is only available from Gatsby in components inside the 'page' and 'template' directories and must be passed down.
 export const UniversalViewer = ({ manifest, location }) => {
   return (
     <StaticQuery

--- a/src/components/Shared/SearchBox/SearchButton/index.js
+++ b/src/components/Shared/SearchBox/SearchButton/index.js
@@ -25,7 +25,7 @@ SearchButton.propTypes = {
   searchReducer: PropTypes.object.isRequired,
   submitSearch: PropTypes.func.isRequired,
   white: PropTypes.bool.isRequired,
-  location: PropTypes.object,
+  location: PropTypes.object.isRequired,
 }
 
 SearchButton.defaultProps = {

--- a/src/components/Shared/SearchBox/SearchButton/index.js
+++ b/src/components/Shared/SearchBox/SearchButton/index.js
@@ -4,12 +4,12 @@ import { connect } from 'react-redux'
 import searchImage from 'assets/icons/svg/baseline-search-24px.svg'
 import searchImageWhite from 'assets/icons/svg/baseline-search-24px-white.svg'
 
-export const SearchButton = ({ white, searchReducer, submitSearch, className }) => {
+export const SearchButton = ({ white, searchReducer, submitSearch, className, location }) => {
   const { rawInput } = searchReducer
   return (
     <button
       className={className}
-      onClick={() => submitSearch(window.location, rawInput)}
+      onClick={() => submitSearch(location, rawInput)}
     >
       <img
         className='searchIcon'
@@ -25,6 +25,7 @@ SearchButton.propTypes = {
   searchReducer: PropTypes.object.isRequired,
   submitSearch: PropTypes.func.isRequired,
   white: PropTypes.bool.isRequired,
+  location: PropTypes.object,
 }
 
 SearchButton.defaultProps = {

--- a/src/components/Shared/SearchBox/SearchField/index.js
+++ b/src/components/Shared/SearchBox/SearchField/index.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { updateInput } from 'store/actions/searchActions'
 
 // You should only have one search field on a page.
-export const SearchField = ({ submitSearch, searchReducer, dispatch, className }) => {
+export const SearchField = ({ submitSearch, searchReducer, dispatch, className, location }) => {
   const { rawInput } = searchReducer
   const fieldLabel = 'Search the Collections'
   return (
@@ -23,7 +23,7 @@ export const SearchField = ({ submitSearch, searchReducer, dispatch, className }
         onKeyDown={(e) => {
         // Submit on enter key press
           if (e.keyCode === 13) {
-            submitSearch(window.location, rawInput)
+            submitSearch(location, rawInput)
           }
         }}
       />
@@ -36,6 +36,7 @@ SearchField.propTypes = {
   submitSearch: PropTypes.func.isRequired,
   searchReducer: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired,
+  location: PropTypes.object,
 }
 
 const mapStateToProps = (state) => {

--- a/src/components/Shared/SearchBox/SearchField/index.js
+++ b/src/components/Shared/SearchBox/SearchField/index.js
@@ -36,7 +36,7 @@ SearchField.propTypes = {
   submitSearch: PropTypes.func.isRequired,
   searchReducer: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired,
-  location: PropTypes.object,
+  location: PropTypes.object.isRequired,
 }
 
 const mapStateToProps = (state) => {

--- a/src/components/Shared/SearchBox/index.js
+++ b/src/components/Shared/SearchBox/index.js
@@ -38,7 +38,7 @@ const SearchBox = ({ location }) => {
 }
 
 SearchBox.propTypes = {
-  location: PropTypes.object,
+  location: PropTypes.object.isRequired,
 }
 
 export default SearchBox

--- a/src/components/Shared/SearchBox/index.js
+++ b/src/components/Shared/SearchBox/index.js
@@ -5,9 +5,9 @@ import queryString from 'query-string'
 import SearchButton from './SearchButton'
 import SearchField from './SearchField'
 import style from './style.module.css'
-
 import helpIcon from 'assets/icons/svg/baseline-help_outline-24px.svg'
 
+// The location prop is only available from Gatsby in components inside the 'page' and 'template' directories and must be passed down.
 const SearchBox = ({ location }) => {
   return (
     <section className={style.searchComponent} >

--- a/src/components/Shared/SearchBox/index.js
+++ b/src/components/Shared/SearchBox/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Link, navigate } from 'gatsby'
 import queryString from 'query-string'
 import SearchButton from './SearchButton'
@@ -7,16 +8,19 @@ import style from './style.module.css'
 
 import helpIcon from 'assets/icons/svg/baseline-help_outline-24px.svg'
 
-const SearchBox = () => {
+const SearchBox = ({ location }) => {
   return (
     <section className={style.searchComponent} >
       <div className={style.searchBox}>
         <SearchField
           className={style.searchField}
+          location={location}
           submitSearch={submitSearch}
+
         />
         <SearchButton
           className={style.searchButton}
+          location={location}
           submitSearch={submitSearch}
         />
       </div>
@@ -33,6 +37,12 @@ const SearchBox = () => {
   )
 }
 
+SearchBox.propTypes = {
+  location: PropTypes.object,
+}
+
+export default SearchBox
+
 export const submitSearch = (location, rawInput) => {
   const qs = queryString.parse(location.search)
   qs.terms = rawInput
@@ -40,5 +50,3 @@ export const submitSearch = (location, rawInput) => {
   qs.perpage = qs.perpage || 12
   navigate(`/search?${queryString.stringify(qs)}`)
 }
-
-export default SearchBox

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { graphql } from 'gatsby'
 import { connect } from 'react-redux'
 import queryString from 'query-string'
@@ -11,22 +12,25 @@ import {
   STATUS_SEARCH_FETCHING,
 } from 'store/actions/searchActions'
 
-const SearchPage = () => {
+const SearchPage = ({ location }) => {
   return (
     <Layout
       title={'Search Results'}
       preMain={
         <React.Fragment>
           <Seo title='Search' />
-          <SearchBox />
+          <SearchBox location={location} />
         </React.Fragment>
       }
     >
-      <Search />
+      <Search location={location} />
     </Layout>
   )
 }
 
+SearchPage.propTypes = {
+  location: PropTypes.object,
+}
 const mapStateToProps = (state) => {
   return { ...state }
 }

--- a/src/pages/viewer.js
+++ b/src/pages/viewer.js
@@ -1,8 +1,15 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import UniversalViewer from 'components/ManifestViews/UniversalViewer'
 
-export default () => {
+export const ViewerPage = ({ location }) => {
   return (
-    <UniversalViewer />
+    <UniversalViewer location={location} />
   )
 }
+
+ViewerPage.propTypes = {
+  location: PropTypes.object,
+}
+
+export default ViewerPage


### PR DESCRIPTION
During static build time `window` is undefined. We are mostly using `window.location` in hydrated components, but this is a safer approach.