### PR TITLE
Create smart Link

### DIFF
--- a/src/components/APIViews/Search/SearchDisplay/PageNum/PaginationButton/index.js
+++ b/src/components/APIViews/Search/SearchDisplay/PageNum/PaginationButton/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { Link } from 'gatsby'
+import Link from 'components/Shared/Link'
 import queryString from 'query-string'
 
 export const PaginationButton = ({ currentPage, prev, searchReducer, location }) => {

--- a/src/components/Layout/PageWrapper/BrandingHeader/LinkedLogo/index.js
+++ b/src/components/Layout/PageWrapper/BrandingHeader/LinkedLogo/index.js
@@ -1,14 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import Link from 'components/Shared/Link'
 
 export const LinkedLogo = ({ href, src, alt }) => {
   if (!href || !src || !alt) {
     return null
   }
   return (
-    <a href={href}>
+    <Link to={href}>
       <img src={src} alt={alt} />
-    </a>
+    </Link>
   )
 }
 

--- a/src/components/Layout/PageWrapper/NavigationHeader/LoginButton/index.js
+++ b/src/components/Layout/PageWrapper/NavigationHeader/LoginButton/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Link } from 'gatsby'
+import Link from 'components/Shared/Link'
 import style from './style.module.css'
 const LoginButton = () => {
   return (

--- a/src/components/Layout/PageWrapper/NavigationHeader/SiteLogo/index.js
+++ b/src/components/Layout/PageWrapper/NavigationHeader/SiteLogo/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { StaticQuery, Link, graphql } from 'gatsby'
+import { StaticQuery, graphql } from 'gatsby'
+import Link from 'components/Shared/Link'
 import style from './style.module.css'
 const siteLogo = require('assets/logos/default.siteLogo.png')
 

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/index.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link } from 'gatsby'
+import Link from 'components/Shared/Link'
 import Thumbnail from 'components/Shared/Thumbnail'
 
 export const ImageSection = ({ iiifManifest }) => {

--- a/src/components/Shared/Breadcrumb/index.js
+++ b/src/components/Shared/Breadcrumb/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link } from 'gatsby'
+import Link from 'components/Shared/Link'
 import style from './style.module.css'
 
 // TODO: MAKE BREADCRUMBS WORK

--- a/src/components/Shared/Link/index.js
+++ b/src/components/Shared/Link/index.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import PropTypes from 'propTypes'
+import { Link as GatsbyLink } from 'gatsby'
+
+// Since DOM elements <a> cannot receive activeClassName
+// and partiallyActive, destructure the prop here and
+// pass it only to GatsbyLink
+const Link = ({ children, to, activeClassName, partiallyActive, ...other }) => {
+  // Tailor the following test to your environment.
+  // This example assumes that any internal link (intended for Gatsby)
+  // will start with exactly one slash, and that anything else is external.
+  const internal = /^\/(?!\/)/.test(to)
+
+  // Use Gatsby Link for internal links, and <a> for others
+  if (internal) {
+    return (
+      <GatsbyLink
+        to={to}
+        activeClassName={activeClassName}
+        partiallyActive={partiallyActive}
+        {...other}
+      >
+        {children}
+      </GatsbyLink>
+    )
+  }
+  return (
+    <a href={to} {...other}>
+      {children}
+    </a>
+  )
+}
+
+Link.propTypes = {
+  children: PropTypes.node.isRequired,
+  to: PropTypes.string.isRequired,
+  activeClassName: PropTypes.string,
+  partiallyActive: PropTypes.bool,
+}
+export default Link

--- a/src/components/Shared/Link/index.js
+++ b/src/components/Shared/Link/index.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'propTypes'
 import { Link as GatsbyLink } from 'gatsby'
 
+// https://www.gatsbyjs.org/docs/gatsby-link/#reminder-use-link-only-for-internal-links
+
 // Since DOM elements <a> cannot receive activeClassName
 // and partiallyActive, destructure the prop here and
 // pass it only to GatsbyLink

--- a/src/components/Shared/Navigation/index.js
+++ b/src/components/Shared/Navigation/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import style from './style.module.css'
-import { Link } from 'gatsby'
+import Link from 'components/Shared/Link'
 
 export const Navigation = ({ links, navClass }) => {
   return (

--- a/src/components/Shared/SearchBox/index.js
+++ b/src/components/Shared/SearchBox/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link, navigate } from 'gatsby'
+import { navigate } from 'gatsby'
+import Link from 'components/Shared/Link'
 import queryString from 'query-string'
 import SearchButton from './SearchButton'
 import SearchField from './SearchField'


### PR DESCRIPTION
`Link` cannot handle external links. We sometimes do not know if the link we are providing will be external, especially if it is in a nested component like `Card` or a list of navigation links.