### PR TITLE
Change default of `yarn watch` to also update coverage report locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "start": "npm run develop",
     "serve": "gatsby serve",
     "test": "jest",
-    "watch": "jest --watch"
+    "watch": "jest --watchAll --coverage"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Very helpful for this:

https://atom.io/packages/coverage-markers