### PR TITLE
Item Page enhancements

### DIFF
--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/AlternateImage/AlternateOverlay/index.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/AlternateImage/AlternateOverlay/index.js
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types'
 import style from './style.module.css'
 
 const AlternateOverlay = ({ index, max, length }) => {
+  // index starts at 1, since we are already showing the first image above this
   // only render on last instance
   // do not render if total shown equals total available
-  if (max === index + 1 && max !== length) {
+  if (max === index && max + 1 !== length) {
     const overlayNumber = length - max
     return (
       <div className={style.alternateOverlay}><span>{`+${overlayNumber}`}</span></div>

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/AlternateImage/AlternateOverlay/test.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/AlternateImage/AlternateOverlay/test.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import AlternateOverlay from './'
+
+test('renders null most of the time', () => {
+  const wrapper = shallow(<AlternateOverlay index={0} max={2} length={5} />)
+  expect(wrapper.find('.alternateOverlay').exists()).toBeFalsy()
+})
+
+test('renders overlay with overlay number', () => {
+  const wrapper = shallow(<AlternateOverlay index={2} max={2} length={5} />)
+  expect(wrapper.find('.alternateOverlay').exists()).toBeTruthy()
+  expect(wrapper.find('.alternateOverlay').text()).toEqual('+3')
+})
+test('renders null when length === max', () => {
+  const wrapper = shallow(<AlternateOverlay index={0} max={2} length={2} />)
+  expect(wrapper.find('.alternateOverlay').exists()).toBeFalsy()
+})

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/AlternateImage/test.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/AlternateImage/test.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import AlternateImage from './'
+import Link from 'components/Shared/Link'
+import Image from 'components/Shared/Image'
+import AlternateOverlay from './AlternateOverlay'
+
+const manifest = {
+  id: 'id',
+}
+
+describe('AlternateImage', () => {
+  test('length == 1', () => {
+    const wrapper = shallow(<AlternateImage iiifManifest={manifest} index={1} max={5} length={1} />)
+
+    expect(wrapper.find(Link).exists()).toBeFalsy()
+    expect(wrapper.find(AlternateOverlay).exists()).toBeFalsy()
+    expect(wrapper.find(Image).exists()).toBeFalsy()
+  })
+
+  test('lenght > 1', () => {
+    const wrapper = shallow(<AlternateImage iiifManifest={manifest} index={1} max={5} length={4} />)
+
+    expect(wrapper.find(Link).props().to).toEqual(`/viewer?manifest=id&cv=1`)
+    expect(wrapper.find(AlternateOverlay).exists()).toBeTruthy()
+    expect(wrapper.find(Image).exists()).toBeTruthy()
+  })
+})

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/index.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/index.js
@@ -10,20 +10,17 @@ export const MAX_IMAGES = 4
 const ItemAlternateViews = ({ iiifManifest }) => {
   const canvases = typy(iiifManifest, 'sequences[0].canvases').safeObject
   if (Array.isArray(canvases)) {
-    // truncate at 4 alternate images
-    const originalLength = canvases.length
-    canvases.length = Math.min(MAX_IMAGES, canvases.length)
     return (
       <div>
         {
-          canvases.map((canvas, index) => {
+          canvases.slice(1, Math.min(MAX_IMAGES + 1, canvases.length)).map((canvas, index) => {
             return (
               <AlternateImage
                 key={index}
                 iiifManifest={iiifManifest}
-                index={index}
+                index={index + 1}
                 max={MAX_IMAGES}
-                length={originalLength}
+                length={canvases.length}
               />
             )
           })

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/test.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/test.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ItemAlternateViews from './'
+import AlternateImage from './AlternateImage'
+
+describe('ItemAlternateViews', () => {
+  test('no more canvases', () => {
+    const manifest = {}
+    const wrapper = shallow(<ItemAlternateViews iiifManifest={manifest} />)
+
+    expect(wrapper.find('div').exists()).toBeFalsy()
+    expect(wrapper.find(AlternateImage).exists()).toBeFalsy()
+  })
+
+  test('some canvases', () => {
+    const manifest = {
+      sequences: [{
+        canvases: ['a', 'b', 'c'],
+      }],
+    }
+    const wrapper = shallow(<ItemAlternateViews iiifManifest={manifest} />)
+
+    expect(wrapper.find('div').exists()).toBeTruthy()
+    expect(wrapper.find(AlternateImage).length).toEqual(2)
+  })
+})

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/index.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/index.js
@@ -27,7 +27,6 @@ export const ImageSection = ({ iiifManifest }) => {
 ImageSection.propTypes = {
   iiifManifest: PropTypes.shape({
     id: PropTypes.string.isRequired,
-    thumbnail: PropTypes.object.isRequired,
   }).isRequired,
 }
 export default ImageSection

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/test.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ImageSection from './'
+import Link from 'components/Shared/Link'
+import Image from 'components/Shared/Image'
+import ExpandIcon from './ExpandIcon'
+import ItemAlternateViews from './ItemAlternateViews'
+
+const manifest = {
+  id: 'id',
+}
+const wrapper = shallow(<ImageSection iiifManifest={manifest} />)
+
+test('ImageSection', () => {
+  expect(wrapper.find('section').exists()).toBeTruthy()
+  expect(wrapper.find(Link).props().to).toEqual('/viewer?manifest=id')
+  expect(wrapper.find(Image).exists()).toBeTruthy()
+  expect(wrapper.find(ExpandIcon).exists()).toBeTruthy()
+  expect(wrapper.find(ItemAlternateViews).exists()).toBeTruthy()
+})

--- a/src/components/ManifestViews/Item/ItemAside/index.js
+++ b/src/components/ManifestViews/Item/ItemAside/index.js
@@ -6,8 +6,8 @@ import ActionButtonGroup from 'components/Shared/ActionButtonGroup'
 export const ItemAside = ({ iiifManifest }) => {
   return (
     <React.Fragment>
-      <ImageSection iiifManifest={iiifManifest} />
       <ActionButtonGroup iiifManifest={iiifManifest} />
+      <ImageSection iiifManifest={iiifManifest} />
     </React.Fragment>
   )
 }

--- a/src/components/ManifestViews/Item/ItemAside/test.js
+++ b/src/components/ManifestViews/Item/ItemAside/test.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ItemAside from './'
+import ImageSection from './ImageSection'
+import ActionButtonGroup from 'components/Shared/ActionButtonGroup'
+
+const wrapper = shallow(<ItemAside iiifManifest={{ id: 'id' }} />)
+
+test('ItemAside', () => {
+  expect(wrapper.find(ImageSection).exists()).toBeTruthy()
+  expect(wrapper.find(ActionButtonGroup).exists()).toBeTruthy()
+})

--- a/src/components/ManifestViews/Item/ItemPreMain/test.js
+++ b/src/components/ManifestViews/Item/ItemPreMain/test.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ItemPreMain from './'
+import SEO from 'components/Shared/Seo'
+import ReturnToSearch from 'components/Shared/ReturnToSearch'
+
+const manifest = {
+  label: 'a label',
+  thumbnail: {
+    '_id': 'picture.png',
+  },
+  description: 'a description',
+}
+const location = {
+  some: 'object',
+}
+const wrapper = shallow(<ItemPreMain iiifManifest={manifest} location={location} />)
+
+test('ItemPreMain', () => {
+  expect(wrapper.find(SEO).props().title).toEqual('a label')
+  expect(wrapper.find(SEO).props().image).toEqual('picture.png')
+  expect(wrapper.find(SEO).props().description).toEqual('a description')
+  expect(wrapper.find(ReturnToSearch).props().location).toEqual({ some: 'object' })
+})

--- a/src/components/ManifestViews/Item/index.js
+++ b/src/components/ManifestViews/Item/index.js
@@ -7,6 +7,7 @@ import MetaDataList from 'components/Shared/MetaDataList'
 import style from './style.module.css'
 
 export const Item = ({ iiifManifest, location }) => {
+  console.log(iiifManifest)
   return (
     <Layout
       preMain={<ItemPreMain iiifManifest={iiifManifest} location={location} />}
@@ -18,7 +19,7 @@ export const Item = ({ iiifManifest, location }) => {
       <p>{iiifManifest.description}</p>
       <MetaDataList metadata={iiifManifest.metadata} />
       <p>{iiifManifest.attribution}</p>
-      <p>{iiifManifest.license}</p>
+      <p dangerouslySetInnerHTML={{ __html: iiifManifest.license }} />
     </Layout>
   )
 }

--- a/src/components/ManifestViews/Item/index.js
+++ b/src/components/ManifestViews/Item/index.js
@@ -15,10 +15,13 @@ export const Item = ({ iiifManifest, location }) => {
       asideClassName={style.itemAside}
       articleClassName={style.itemMain}
     >
-      <p>{iiifManifest.description}</p>
+      <p className={style.description}>{iiifManifest.description}</p>
       <MetaDataList metadata={iiifManifest.metadata} />
-      <p>{iiifManifest.attribution}</p>
-      <p dangerouslySetInnerHTML={{ __html: iiifManifest.license }} />
+      <p className={style.attribution}>{iiifManifest.attribution}</p>
+      <p
+        className={style.license}
+        dangerouslySetInnerHTML={{ __html: iiifManifest.license }}
+      />
     </Layout>
   )
 }

--- a/src/components/ManifestViews/Item/index.js
+++ b/src/components/ManifestViews/Item/index.js
@@ -7,7 +7,6 @@ import MetaDataList from 'components/Shared/MetaDataList'
 import style from './style.module.css'
 
 export const Item = ({ iiifManifest, location }) => {
-  console.log(iiifManifest)
   return (
     <Layout
       preMain={<ItemPreMain iiifManifest={iiifManifest} location={location} />}

--- a/src/components/ManifestViews/Item/test.js
+++ b/src/components/ManifestViews/Item/test.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import Item from './'
+import Layout from 'components/Layout'
+import MetaDataList from 'components/Shared/MetaDataList'
+
+const manifest = {
+  label: 'fancy label',
+  description: 'some text',
+  metadata: [{ some: 'metadata' }],
+  attribution: 'some guy',
+  license: `<a href='/link'>Copyright</a>`,
+}
+const location = {}
+
+const wrapper = shallow(<Item iiifManifest={manifest} location={location} />)
+
+test('Item', () => {
+  expect(wrapper.find(Layout).props().title).toEqual('fancy label')
+  expect(wrapper.find('.description').text()).toEqual('some text')
+  expect(wrapper.find(MetaDataList).props().metadata).toEqual([{ some: 'metadata' }])
+  expect(wrapper.find('.attribution').text()).toEqual('some guy')
+  expect(wrapper.find('.license').html()).toContain(`<a href='/link'>Copyright</a>`)
+})

--- a/src/components/Shared/ActionButtonGroup/index.js
+++ b/src/components/Shared/ActionButtonGroup/index.js
@@ -13,22 +13,7 @@ import style from './style.module.css'
 const ActionButtonGroup = ({ iiifManifest }) => {
   return (
     <section className={style.actionButtons}>
-      <ManifestLink manifestUrl={iiifManifest.id} />
-      <ActionButton
-        name='download'
-        action={downloadAction}
-        icon={downloadImg}
-      />
-      <ActionButton
-        name='print'
-        action={printAction}
-        icon={print}
-      />
-      <ActionButton
-        name='share'
-        action={shareAction}
-        icon={share}
-      />
+
       <ActionButton
         name='bookmark'
         action={bookmarkAction}
@@ -36,6 +21,22 @@ const ActionButtonGroup = ({ iiifManifest }) => {
         activeIcon={bookmarkActive}
         isActive
       />
+      <ActionButton
+        name='share'
+        action={shareAction}
+        icon={share}
+      />
+      <ActionButton
+        name='print'
+        action={printAction}
+        icon={print}
+      />
+      <ActionButton
+        name='download'
+        action={downloadAction}
+        icon={downloadImg}
+      />
+      <ManifestLink manifestUrl={iiifManifest.id} />
     </section>
   )
 }

--- a/src/components/Shared/ActionButtonGroup/index.js
+++ b/src/components/Shared/ActionButtonGroup/index.js
@@ -13,7 +13,6 @@ import style from './style.module.css'
 const ActionButtonGroup = ({ iiifManifest }) => {
   return (
     <section className={style.actionButtons}>
-
       <ActionButton
         name='bookmark'
         action={bookmarkAction}
@@ -54,7 +53,6 @@ export const shareAction = () => {
 
 export const printAction = () => {
   window.print()
-  console.log('print')
 }
 
 export const downloadAction = () => {

--- a/src/components/Shared/ActionButtonGroup/test.js
+++ b/src/components/Shared/ActionButtonGroup/test.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import ActionButtonGroup,
+{
+  bookmarkAction,
+  shareAction,
+  printAction,
+  downloadAction,
+} from './'
+import ActionButton from './ActionButton'
+
+const print = jest.fn()
+const window = global.window
+Object.defineProperty(window, 'print', print)
+
+const manifest = {
+  id: 'https://iiif.iiif',
+}
+const wrapper = shallow(<ActionButtonGroup iiifManifest={manifest} />)
+
+test('Renders 4 actions buttons and an wrapper', () => {
+  expect(wrapper.find('actionButton')).toBeTruthy()
+  expect(wrapper.find(ActionButton).length).toEqual(4)
+})
+
+const spyOnLog = jest.spyOn(console, 'log')
+beforeEach(() => {
+  spyOnLog.mockReset()
+})
+
+// TODO test functions (after functions written)
+test('bookmarkAction', () => {
+  bookmarkAction()
+  expect(spyOnLog).toHaveBeenCalled()
+})
+
+test('shareAction', () => {
+  shareAction()
+  expect(spyOnLog).toHaveBeenCalled()
+})
+
+test('printAction', () => {
+  // jest and jsdom will complain about window.print even with proper mocking so we suppress the error
+  jest.spyOn(console, 'error')
+  global.console.error.mockImplementation(() => {})
+
+  const printSpy = jest.spyOn(window, 'print')
+
+  printAction()
+  expect(printSpy).toHaveBeenCalled()
+})
+
+test('downloadAction', () => {
+  downloadAction()
+  expect(spyOnLog).toHaveBeenCalled()
+})


### PR DESCRIPTION
* MEL-387 - Fix navigating between items losing overlay for additional images on Item page. (Also start additional images at index of 1 so we're not showing the first image twice.)
* MEL-388 - Move action buttons above image on Item page.
* MEL-389 - Move IIIF icon to last place in Action Button group. (Also reordered other icons left to right in terms of what is most common action).
* MEL-385 - "Description, rights/license does not appear on the metadata list outside of the viewer" - Description was already added in this version. License field appears to be html, and is now being set as such.