### PR TITLE
MEL-425 Back button on Universal Viewer

### DIFF
--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/AlternateImage/index.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/AlternateImage/index.js
@@ -4,14 +4,16 @@ import Link from 'components/Shared/Link'
 import Image from 'components/Shared/Image'
 import AlternateOverlay from './AlternateOverlay'
 import getImageService from 'utils/getImageService'
+import buildReferalState from 'utils/buildReferalState'
 import style from './style.module.css'
 
-export const AlternateImage = ({ iiifManifest, index, max, length }) => {
+export const AlternateImage = ({ iiifManifest, index, max, length, location }) => {
   if (length > 1) {
     return (
       <Link
         className={style.alternateLink}
         to={`/viewer?manifest=${encodeURIComponent(iiifManifest.id)}&cv=${index}`}
+        state={buildReferalState(location, { type: 'item', backLink: location.href })}
       >
         <AlternateOverlay
           index={index}
@@ -35,7 +37,7 @@ AlternateImage.propTypes = {
   index: PropTypes.number.isRequired,
   max: PropTypes.number.isRequired,
   length: PropTypes.number.isRequired,
-
+  location: PropTypes.object.isRequired,
 }
 
 export default AlternateImage

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/AlternateImage/test.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/AlternateImage/test.js
@@ -8,10 +8,10 @@ import AlternateOverlay from './AlternateOverlay'
 const manifest = {
   id: 'id',
 }
-
+const location = {}
 describe('AlternateImage', () => {
   test('length == 1', () => {
-    const wrapper = shallow(<AlternateImage iiifManifest={manifest} index={1} max={5} length={1} />)
+    const wrapper = shallow(<AlternateImage iiifManifest={manifest} index={1} max={5} length={1} location={location} />)
 
     expect(wrapper.find(Link).exists()).toBeFalsy()
     expect(wrapper.find(AlternateOverlay).exists()).toBeFalsy()
@@ -19,7 +19,7 @@ describe('AlternateImage', () => {
   })
 
   test('lenght > 1', () => {
-    const wrapper = shallow(<AlternateImage iiifManifest={manifest} index={1} max={5} length={4} />)
+    const wrapper = shallow(<AlternateImage iiifManifest={manifest} index={1} max={5} length={4} location={location} />)
 
     expect(wrapper.find(Link).props().to).toEqual(`/viewer?manifest=id&cv=1`)
     expect(wrapper.find(AlternateOverlay).exists()).toBeTruthy()

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/index.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/index.js
@@ -7,7 +7,7 @@ import AlternateImage from './AlternateImage'
 // tests if/when this number changes
 export const MAX_IMAGES = 4
 
-const ItemAlternateViews = ({ iiifManifest }) => {
+const ItemAlternateViews = ({ iiifManifest, location }) => {
   const canvases = typy(iiifManifest, 'sequences[0].canvases').safeObject
   if (Array.isArray(canvases)) {
     return (
@@ -21,6 +21,7 @@ const ItemAlternateViews = ({ iiifManifest }) => {
                 index={index + 1}
                 max={MAX_IMAGES}
                 length={canvases.length}
+                location={location}
               />
             )
           })
@@ -33,6 +34,7 @@ const ItemAlternateViews = ({ iiifManifest }) => {
 
 ItemAlternateViews.propTypes = {
   iiifManifest: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
 }
 
 export default ItemAlternateViews

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/test.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/ItemAlternateViews/test.js
@@ -4,9 +4,10 @@ import ItemAlternateViews from './'
 import AlternateImage from './AlternateImage'
 
 describe('ItemAlternateViews', () => {
+  const location = {}
   test('no more canvases', () => {
     const manifest = {}
-    const wrapper = shallow(<ItemAlternateViews iiifManifest={manifest} />)
+    const wrapper = shallow(<ItemAlternateViews iiifManifest={manifest} location={location} />)
 
     expect(wrapper.find('div').exists()).toBeFalsy()
     expect(wrapper.find(AlternateImage).exists()).toBeFalsy()
@@ -18,7 +19,7 @@ describe('ItemAlternateViews', () => {
         canvases: ['a', 'b', 'c'],
       }],
     }
-    const wrapper = shallow(<ItemAlternateViews iiifManifest={manifest} />)
+    const wrapper = shallow(<ItemAlternateViews iiifManifest={manifest} location={location} />)
 
     expect(wrapper.find('div').exists()).toBeTruthy()
     expect(wrapper.find(AlternateImage).length).toEqual(2)

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/index.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/index.js
@@ -5,12 +5,15 @@ import Image from 'components/Shared/Image'
 import ExpandIcon from './ExpandIcon'
 import ItemAlternateViews from './ItemAlternateViews'
 import getImageService from 'utils/getImageService'
+import buildReferalState from 'utils/buildReferalState'
 import style from './style.module.css'
-export const ImageSection = ({ iiifManifest }) => {
+export const ImageSection = ({ location, iiifManifest }) => {
   return (
     <section>
-      <Link to={`/viewer?manifest=${encodeURIComponent(iiifManifest.id)}`}
+      <Link
+        to={`/viewer?manifest=${encodeURIComponent(iiifManifest.id)}`}
         className={style.link}
+        state={buildReferalState(location, { type: 'item', backLink: location.href })}
       >
         <Image
           service={getImageService(iiifManifest)}
@@ -19,7 +22,7 @@ export const ImageSection = ({ iiifManifest }) => {
         />
         <ExpandIcon />
       </Link>
-      <ItemAlternateViews iiifManifest={iiifManifest} />
+      <ItemAlternateViews iiifManifest={iiifManifest} location={location} />
     </section>
   )
 }
@@ -28,5 +31,6 @@ ImageSection.propTypes = {
   iiifManifest: PropTypes.shape({
     id: PropTypes.string.isRequired,
   }).isRequired,
+  location: PropTypes.object.isRequired,
 }
 export default ImageSection

--- a/src/components/ManifestViews/Item/ItemAside/ImageSection/test.js
+++ b/src/components/ManifestViews/Item/ItemAside/ImageSection/test.js
@@ -9,7 +9,7 @@ import ItemAlternateViews from './ItemAlternateViews'
 const manifest = {
   id: 'id',
 }
-const wrapper = shallow(<ImageSection iiifManifest={manifest} />)
+const wrapper = shallow(<ImageSection iiifManifest={manifest} location={{}} />)
 
 test('ImageSection', () => {
   expect(wrapper.find('section').exists()).toBeTruthy()

--- a/src/components/ManifestViews/Item/ItemAside/index.js
+++ b/src/components/ManifestViews/Item/ItemAside/index.js
@@ -3,16 +3,17 @@ import PropTypes from 'prop-types'
 import ImageSection from './ImageSection'
 import ActionButtonGroup from 'components/Shared/ActionButtonGroup'
 
-export const ItemAside = ({ iiifManifest }) => {
+export const ItemAside = ({ location, iiifManifest }) => {
   return (
     <React.Fragment>
       <ActionButtonGroup iiifManifest={iiifManifest} />
-      <ImageSection iiifManifest={iiifManifest} />
+      <ImageSection iiifManifest={iiifManifest} location={location} />
     </React.Fragment>
   )
 }
 ItemAside.propTypes = {
   iiifManifest: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
 }
 
 export default ItemAside

--- a/src/components/ManifestViews/Item/ItemAside/test.js
+++ b/src/components/ManifestViews/Item/ItemAside/test.js
@@ -4,7 +4,7 @@ import ItemAside from './'
 import ImageSection from './ImageSection'
 import ActionButtonGroup from 'components/Shared/ActionButtonGroup'
 
-const wrapper = shallow(<ItemAside iiifManifest={{ id: 'id' }} />)
+const wrapper = shallow(<ItemAside iiifManifest={{ id: 'id' }} location={{}} />)
 
 test('ItemAside', () => {
   expect(wrapper.find(ImageSection).exists()).toBeTruthy()

--- a/src/components/ManifestViews/Item/index.js
+++ b/src/components/ManifestViews/Item/index.js
@@ -11,7 +11,7 @@ export const Item = ({ iiifManifest, location }) => {
     <Layout
       preMain={<ItemPreMain iiifManifest={iiifManifest} location={location} />}
       title={iiifManifest.label}
-      aside={<ItemAside iiifManifest={iiifManifest} />}
+      aside={<ItemAside iiifManifest={iiifManifest} location={location} />}
       asideClassName={style.itemAside}
       articleClassName={style.itemMain}
       location={location}

--- a/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/BackToItem/index.js
+++ b/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/BackToItem/index.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import typy from 'typy'
+import Link from 'components/Shared/Link'
+import style from './style.module.css'
+const BackToItem = ({ location }) => {
+  if (typy(location, 'state.referal.type').safeString === 'item') {
+    return (
+      <Link
+        className={style.backLink}
+        to={location.state.referal.backLink}
+      >≪ Return to Item</Link>
+    )
+  }
+  return null
+}
+
+BackToItem.propTypes = {
+  location: PropTypes.object,
+}
+export default BackToItem

--- a/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/BackToItem/style.module.css
+++ b/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/BackToItem/style.module.css
@@ -1,0 +1,19 @@
+.backLink {
+  color: white;
+  left: 0;
+  margin: .75rem;
+  position: absolute;
+  text-decoration: none;
+  top: 0;
+  z-index: 1;
+}
+
+.backLink:hover {
+  color: #dedede;
+}
+
+@media (max-width: 799px) {
+  .backLink {
+    display: none;
+  }
+}

--- a/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/BackToItem/test.js
+++ b/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/BackToItem/test.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import BackToItem from './'
+
+describe('BackToItem', () => {
+  test('show', () => {
+    const location = {
+      state: {
+        referal: {
+          type: 'item',
+          backLink: '/back-to-item',
+        },
+      },
+    }
+    const wrapper = shallow(<BackToItem location={location} />)
+    expect(wrapper.find('.backLink').props().to).toEqual('/back-to-item')
+  })
+  test('do not show', () => {
+    const wrapper = shallow(<BackToItem location={{}} />)
+    expect(wrapper.find('.backLink').exists()).toBeFalsy()
+  })
+})

--- a/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/index.js
+++ b/src/components/ManifestViews/UniversalViewer/UniversalViewerLayout/index.js
@@ -5,6 +5,7 @@ import Layout from 'components/Layout'
 import PrivateRoute from 'components/Layout/PrivateRoute/'
 import SkipToMain from 'components/Layout/PageWrapper/SkipToMain'
 import SEO from 'components/Shared/Seo'
+import BackToItem from './BackToItem'
 import style from './style.module.css'
 
 export const UniversalViewerLayout = ({ data, manifest, location, requireLogin }) => {
@@ -25,6 +26,7 @@ export const UniversalViewerLayout = ({ data, manifest, location, requireLogin }
       <SEO title={`Universal Viewer`} />
       <h1 className='accessibilityOnly'>Universal Viewer</h1>
       <main id='mainContent'>
+        <BackToItem location={location} />
         <iframe
           allowFullScreen
           id='universalViewer'

--- a/src/components/Shared/Card/index.js
+++ b/src/components/Shared/Card/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import Link from 'components/Shared/Link'
 import Image from 'components/Shared/Image'
 import getImageService from 'utils/getImageService'
+import buildReferalState from 'utils/buildReferalState'
 import './style.css'
 
 const Card = ({
@@ -18,7 +19,7 @@ const Card = ({
   const imageService = getImageService(iiifManifest)
   return (
     <Link to={target}
-      state={buildState(location, referal)}
+      state={buildReferalState(location, referal)}
       className={cardClass}
     >
       <article className='cardWrapper'>
@@ -57,12 +58,3 @@ Card.defaultProps = {
   cardClass: 'basicCard',
 }
 export default Card
-
-const buildState = (location, referal) => {
-  if (location && referal) {
-    return {
-      referal: referal,
-    }
-  }
-  return null
-}

--- a/src/components/Shared/ReturnToSearch/index.js
+++ b/src/components/Shared/ReturnToSearch/index.js
@@ -10,7 +10,7 @@ export const ReturnToSearch = ({ location }) => {
       <nav className={style.returnToSearch}>
         <Link
           to={`/search${location.state.referal.query}`}
-        >Return to Search</Link>
+        >≪ Return to Search</Link>
       </nav>
     )
   }

--- a/src/utils/__tests__/test.buildReferalState.js
+++ b/src/utils/__tests__/test.buildReferalState.js
@@ -1,0 +1,12 @@
+import buildReferalState from '../buildReferalState'
+
+describe('buildReferalState', () => {
+  test('empty', () => {
+    const nullResult = buildReferalState(null, null)
+    expect(nullResult).toEqual(null)
+  })
+  test('referal', () => {
+    const result = buildReferalState({ some: 'location' }, { my: 'referal' })
+    expect(result).toEqual({ referal: { my: 'referal' } })
+  })
+})

--- a/src/utils/buildReferalState.js
+++ b/src/utils/buildReferalState.js
@@ -1,0 +1,8 @@
+export default (location, referal) => {
+  if (location && referal) {
+    return {
+      referal: referal,
+    }
+  }
+  return null
+}


### PR DESCRIPTION
Added link based on referring item to Universal viewer. A couple of notes:
* Universal viewer UI changes at 800px, so there is not a good place to put the link. so it is hidden with CSS at viewport widths below 800px.
* The link is based on the referring Item page (sent by Link's location state), so going directly to the UV from say a Google search or doing a hard page refresh will not display the link. I think this is the correct behavior at present as there is the potential to view a manifest in the UV that does not have a corresponding item page. If we can refactor the UV page to be statically built, we should consider refactoring to generate the link from the manifest data instead.