### PR TITLE
MEL-419 Grid/List view in new search results page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,6 +10,10 @@ module.exports = {
     // apis and embedded urls
     universalViewerBaseURL: process.env.MARBLE_UNIVERSAL_VIEWER_BASE_URL || `https://viewer-iiif.library.nd.edu/universalviewer/index.html`,
     primoSearchBaseURL: process.env.MARBLE_PRIMO_BASE_URL || `https://a1fc3ld3d7.execute-api.us-east-1.amazonaws.com/dev/primo/v1/search`,
+    searchBase: {
+      app: 'website',
+      url: 'https://search-super-testy-search-test-xweemgolqgtta6mzqnuvc6ogbq.us-east-1.es.amazonaws.com',
+    },
 
     // branding
     institutionURL: process.env.MARBLE_INSTITUTION_URL || `http://nd.edu`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,8 +11,8 @@ module.exports = {
     universalViewerBaseURL: process.env.MARBLE_UNIVERSAL_VIEWER_BASE_URL || `https://viewer-iiif.library.nd.edu/universalviewer/index.html`,
     primoSearchBaseURL: process.env.MARBLE_PRIMO_BASE_URL || `https://a1fc3ld3d7.execute-api.us-east-1.amazonaws.com/dev/primo/v1/search`,
     searchBase: {
-      app: 'website',
-      url: 'https://search-super-testy-search-test-xweemgolqgtta6mzqnuvc6ogbq.us-east-1.es.amazonaws.com',
+      app: process.env.MARBLE_SEARCHBASE_APP || 'website',
+      url: process.env.MARBLE_SEARCHBASE_URL || 'https://search-super-testy-search-test-xweemgolqgtta6mzqnuvc6ogbq.us-east-1.es.amazonaws.com',
     },
 
     // branding

--- a/src/components/ManifestViews/Collection/index.js
+++ b/src/components/ManifestViews/Collection/index.js
@@ -1,9 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import typy from 'typy'
 import Layout from 'components/Layout'
-import DisplayViewToggle from 'components/Shared/DisplayViewToggle'
+import DisplayViewToggle, { getActiveSettings } from 'components/Shared/DisplayViewToggle'
 import CollectionAside from './CollectionAside'
 import CollectionPreMain from './CollectionPreMain'
 import ResponsiveGridList from 'components/Shared/ResponsiveGridList'
@@ -11,11 +10,10 @@ import Card from 'components/Shared/Card'
 import {
   COLLECTION_PAGE,
   DISPLAY_GRID,
-  DISPLAY_LIST,
 } from 'store/actions/displayActions'
 
 export const Collection = ({ iiifManifest, location, displayReducer }) => {
-  const activeSettings = getActiveSettings(displayReducer)
+  const activeSettings = getActiveSettings(displayReducer, COLLECTION_PAGE)
   const cardClass = displayReducer[COLLECTION_PAGE] || DISPLAY_GRID
   return (
     <Layout
@@ -67,22 +65,3 @@ const mapStateToProps = (state) => {
   return { ...state }
 }
 export default connect(mapStateToProps)(Collection)
-
-export const getActiveSettings = (displayReducer) => {
-  const gridListSettings = {
-    [DISPLAY_GRID]: {
-      breakpoints: { lg: 680, md: 480, sm: 240 },
-      cols: { lg: 6, md: 4, sm: 2 },
-      rowHeight: 200,
-      cardWidth:  2,
-    },
-    [DISPLAY_LIST]: {
-      breakpoints: { lg: 680, md: 480, sm: 240 },
-      cols: { lg: 6, md: 6, sm: 6 },
-      rowHeight: 250,
-      cardWidth:  6,
-    },
-  }
-  const view = typy(displayReducer, `[${COLLECTION_PAGE}]`).safeObject
-  return typy(gridListSettings, `[${view}]`).safeObject || gridListSettings[DISPLAY_GRID]
-}

--- a/src/components/Search/SearchPreMain/index.js
+++ b/src/components/Search/SearchPreMain/index.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  DataSearch,
+  SelectedFilters,
+} from '@appbaseio/reactivesearch'
+import Seo from 'components/Shared/Seo/'
+import style from './style.module.css'
+
+const SearchPreMain = ({ components }) => {
+  return (
+    <div className={style.searchHead}>
+      <Seo title='Search' />
+      <DataSearch
+        componentId='SearchSensor'
+        dataField={['title', 'creator', 'fulltext', 'type', 'systemId']}
+        filterLabel='Search'
+        highlight
+        highlightField={['title', 'creator', 'systemId']}
+        react={{ 'and': components }}
+        URLParams
+      />
+      <SelectedFilters />
+    </div>
+  )
+}
+
+SearchPreMain.propTypes = {
+  components: PropTypes.array.isRequired,
+}
+
+export default SearchPreMain

--- a/src/components/Search/SearchPreMain/style.module.css
+++ b/src/components/Search/SearchPreMain/style.module.css
@@ -1,0 +1,4 @@
+.searchHead {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}

--- a/src/components/Search/SearchPreMain/test.js
+++ b/src/components/Search/SearchPreMain/test.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import SearchPreMain from './'
+import {
+  DataSearch,
+  SelectedFilters,
+} from '@appbaseio/reactivesearch'
+import Seo from 'components/Shared/Seo/'
+
+test('SearchPreMain', () => {
+  const wrapper = shallow(<SearchPreMain components={[]} />)
+  expect(wrapper.find('.searchHead').exists()).toBeTruthy()
+  expect(wrapper.find(Seo).props().title).toEqual('Search')
+  expect(wrapper.find(DataSearch).exists()).toBeTruthy()
+  expect(wrapper.find(SelectedFilters).exists()).toBeTruthy()
+})

--- a/src/components/Search/SearchResults/index.js
+++ b/src/components/Search/SearchResults/index.js
@@ -1,0 +1,79 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { ReactiveList } from '@appbaseio/reactivesearch'
+import Card from 'components/Shared/Card'
+import DisplayViewToggle, { getActiveSettings } from 'components/Shared/DisplayViewToggle'
+import ResponsiveGridList from 'components/Shared/ResponsiveGridList'
+import Loading from 'components/Shared/Loading'
+import {
+  SEARCH_PAGE,
+  DISPLAY_LIST,
+} from 'store/actions/displayActions'
+
+const SearchResults = ({ location, components, displayReducer }) => {
+  const activeSettings = getActiveSettings(displayReducer, SEARCH_PAGE)
+  const cardClass = displayReducer[SEARCH_PAGE] || DISPLAY_LIST
+
+  return (
+    <ReactiveList
+      componentId='SearchResult'
+      dataField={'title'}
+      react={{
+        'and': components,
+      }}
+      excludeFields={['fulltext']}
+      size={48}
+      loader={<Loading />}
+      scrollOnChange
+      infiniteScroll={false}
+      pagination
+      renderNoResults={() => (<div>No matches could be found</div>)}
+      render={({ data, error, loading }) => {
+        if (!error && !loading && data) {
+          return (
+            <DisplayViewToggle
+              page={SEARCH_PAGE}
+            >
+              <ResponsiveGridList
+                breakpoints={activeSettings.breakpoints}
+                cols={activeSettings.cols}
+                rowHeight={activeSettings.rowHeight}
+                cardWidth={activeSettings.cardWidth}
+                measureBeforeMount
+              >
+                {
+                  data.map(res => (
+                    <div key={res['_id']}>
+                      <Card
+                        label={res.title}
+                        image={res.thumbnail}
+                        target={res.url}
+                        location={location}
+                        referal={{ type: 'search', query: location.search }}
+                        cardClass={cardClass}
+                      >
+                        <div className='description'>{res.description}</div>
+                        <div>{res.creator}</div>
+                      </Card>
+                    </div>
+                  )
+                  )
+                }
+              </ResponsiveGridList>
+            </DisplayViewToggle>
+          )
+        }
+        return null
+      }}
+    />
+  )
+}
+
+SearchResults.propTypes = {
+
+  location: PropTypes.object.isRequired,
+  components: PropTypes.array.isRequired,
+  displayReducer: PropTypes.object.isRequired,
+}
+
+export default SearchResults

--- a/src/components/Search/SearchTools/index.js
+++ b/src/components/Search/SearchTools/index.js
@@ -1,0 +1,91 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import {
+  MultiList,
+  SingleDataList,
+  RangeSlider,
+  MultiDropdownList,
+} from '@appbaseio/reactivesearch'
+
+const SearchTools = ({ components }) => {
+  return (
+    <React.Fragment>
+      <MultiList
+        componentId='FormatListAggregate'
+        dataField='type.keyword'
+        title='Format'
+        size={7}
+        filterLabel='Format'
+        showSearch={false}
+        react={{ 'and': components }}
+        URLParams
+      />
+      <MultiDropdownList
+        componentId='LocationListAggregate'
+        dataField='place.keyword'
+        title='Places'
+        filterLabel='Places'
+        size={15}
+        sortBy='count'
+        showSearch={false}
+        react={{ 'and': components }}
+        URLParams
+      />
+      <RangeSlider
+        componentId='DynamicYearSlider'
+        dataField='year'
+        title='Date'
+        filterLabel='Date'
+        stepValue={5}
+        interval={5}
+        react={{ 'and': components }}
+        rangeLabels={{
+          'start': '1880',
+          'end': '2010',
+        }}
+        range={{
+          'start': 1880,
+          'end': 2010,
+        }}
+        URLParams
+      />
+      <SingleDataList
+        componentId='CampusLocationAggregate'
+        dataField='repository.keyword'
+        title='Campus Location'
+        filterLabel='Campus Location'
+        showSearch={false}
+        URLParams
+        data={
+          [{
+            label: 'Rare Books and Special Collections',
+            value: 'SPEC RBSC',
+          }, {
+            label: 'Snite Museum of Art',
+            value: 'SNITE',
+          }, {
+            label: 'University Archives',
+            value: 'ARCHIVES',
+          }]
+        }
+        react={{ 'and': components }}
+      />
+      <MultiDropdownList
+        componentId='LanguageListAggregate'
+        dataField='language.keyword'
+        title='Language'
+        sortBy='count'
+        filterLabel='Language'
+        showSearch={false}
+        react={{ 'and': components }}
+        URLParams
+      />
+    </React.Fragment>
+  )
+}
+
+SearchTools.propTypes = {
+  components: PropTypes.array.isRequired,
+}
+
+export default SearchTools

--- a/src/components/Search/SearchTools/test.js
+++ b/src/components/Search/SearchTools/test.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import SearchTools from './'
+import {
+  MultiList,
+  SingleDataList,
+  RangeSlider,
+  MultiDropdownList,
+} from '@appbaseio/reactivesearch'
+
+test('SearchTools', () => {
+  const wrapper = shallow(<SearchTools components={[]} />)
+  expect(wrapper.find(MultiList).exists()).toBeTruthy()
+  expect(wrapper.find(SingleDataList).exists()).toBeTruthy()
+  expect(wrapper.find(RangeSlider).exists()).toBeTruthy()
+  expect(wrapper.find(MultiDropdownList).exists()).toBeTruthy()
+})

--- a/src/components/Search/index.js
+++ b/src/components/Search/index.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import Layout from 'components/Layout'
+import SearchPreMain from './SearchPreMain'
+import SearchTools from './SearchTools'
+import SearchResults from './SearchResults'
+import { ReactiveBase } from '@appbaseio/reactivesearch'
+
+export const components = ['SearchResult', 'SearchSensor', 'DynamicYearSlider', 'CampusLocationAggregate', 'LanguageListAggregate', 'LocationListAggregate', 'FormatListAggregate']
+
+export const Search = ({ searchBase, location, displayReducer }) => {
+  return (
+    <ReactiveBase
+      app={searchBase.app}
+      url={searchBase.url}>
+      <Layout
+        location={location}
+        preMain={<SearchPreMain components={components} />}
+        aside={<SearchTools components={components} />}
+      >
+        <SearchResults
+          location={location}
+          components={components}
+          displayReducer={displayReducer}
+        />
+      </Layout>
+    </ReactiveBase>
+  )
+}
+
+Search.propTypes = {
+  searchBase: PropTypes.shape({
+    app: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  }).isRequired,
+  location: PropTypes.object.isRequired,
+  displayReducer: PropTypes.object.isRequired,
+}
+
+const mapStateToProps = (state) => {
+  return { ...state }
+}
+
+export default connect(mapStateToProps)(Search)

--- a/src/components/Search/test.js
+++ b/src/components/Search/test.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { Search, components } from './'
+import Layout from 'components/Layout'
+import SearchResults from './SearchResults'
+import { ReactiveBase } from '@appbaseio/reactivesearch'
+
+test('Search', () => {
+  const searchBase = {
+    app: 'myApp',
+    url: 'http://search.url',
+  }
+  const location = {}
+  const displayReducer = {}
+
+  const wrapper = shallow(<Search searchBase={searchBase} location={location} displayReducer={displayReducer} />)
+  expect(wrapper.find(ReactiveBase).props().app).toEqual('myApp')
+  expect(wrapper.find(ReactiveBase).props().url).toEqual('http://search.url')
+  expect(wrapper.find(Layout).exists()).toBeTruthy()
+  expect(wrapper.find(SearchResults).props().components).toEqual(components)
+})

--- a/src/components/Shared/DisplayViewToggle/index.js
+++ b/src/components/Shared/DisplayViewToggle/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import typy from 'typy'
 import { connect } from 'react-redux'
 import ToggleButton from './ToggleButton'
 import style from './style.module.css'
@@ -52,3 +53,22 @@ const mapStateToProps = (state) => {
   return { ...state }
 }
 export default connect(mapStateToProps)(DisplayViewToggle)
+
+export const getActiveSettings = (displayReducer, reducer) => {
+  const gridListSettings = {
+    [DISPLAY_GRID]: {
+      breakpoints: { lg: 680, md: 480, sm: 240 },
+      cols: { lg: 6, md: 4, sm: 2 },
+      rowHeight: 200,
+      cardWidth:  2,
+    },
+    [DISPLAY_LIST]: {
+      breakpoints: { lg: 680, md: 480, sm: 240 },
+      cols: { lg: 6, md: 6, sm: 6 },
+      rowHeight: 250,
+      cardWidth:  6,
+    },
+  }
+  const view = typy(displayReducer, `[${reducer}]`).safeObject
+  return typy(gridListSettings, `[${view}]`).safeObject || gridListSettings[DISPLAY_GRID]
+}

--- a/src/pages/search-new.js
+++ b/src/pages/search-new.js
@@ -1,223 +1,29 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { graphql } from 'gatsby'
-import { connect } from 'react-redux'
-import queryString from 'query-string'
-import Layout from 'components/Layout'
-import Search from 'components/APIViews/Search'
-import SearchBox from 'components/Shared/SearchBox'
-import Seo from 'components/Shared/Seo'
-import Card from 'components/Shared/Card'
-import ResponsiveGridList from 'components/Shared/ResponsiveGridList'
-import Loading from 'components/Shared/Loading'
+import Search from 'components/Search'
 
-import {
-  submitSearch,
-  STATUS_SEARCH_FETCHING,
-} from 'store/actions/searchActions'
-import { ReactiveBase, DataSearch, MultiList, SingleDataList, ReactiveList, RangeSlider, MultiDropdownList, MultiDataList, SelectedFilters } from '@appbaseio/reactivesearch'
-
-const components = ['SearchResult', 'SearchSensor', 'DynamicYearSlider', 'CampusLocationAggregate', 'LanguageListAggregate', 'LocationListAggregate', 'FormatListAggregate']
-
-const SearchPage = ({ location }) => {
-  return (
-    <ReactiveBase
-      app='website'
-      url='https://search-super-testy-search-test-xweemgolqgtta6mzqnuvc6ogbq.us-east-1.es.amazonaws.com'>
-
-      <Layout
-        title={''}
-        preMain={
-          <React.Fragment>
-            <DataSearch
-              componentId='SearchSensor'
-              dataField={['title', 'creator', 'fulltext', 'type', 'systemId']}
-              filterLabel='Search'
-              highlight
-              highlightField={'title', 'creator', 'systemId'}
-              react={{
-                'and': components,
-              }}
-              URLParams
-            />
-            <SelectedFilters />
-          </React.Fragment>
-        }
-        location={location}
-        aside={
-          <React.Fragment>
-            <MultiList
-              componentId='FormatListAggregate'
-              dataField='type.keyword'
-              title='Format'
-              size={7}
-              filterLabel='Format'
-              showSearch={false}
-              react={{
-                'and': components,
-              }}
-              URLParams
-            />
-            <MultiDropdownList
-              componentId='LocationListAggregate'
-              dataField='place.keyword'
-              title='Places'
-              filterLabel='Places'
-              size={15}
-              sortBy='count'
-              showSearch={false}
-              react={{
-                'and': components,
-              }}
-              URLParams
-            />
-            <RangeSlider
-              componentId='DynamicYearSlider'
-              dataField='year'
-              title='Date'
-              filterLabel='Date'
-              stepValue={5}
-              interval={5}
-              react={{
-                'and': components,
-              }}
-              rangeLabels={{
-                'start': '1880',
-                'end': '2010',
-              }}
-              range={{
-                'start': 1880,
-                'end': 2010,
-              }}
-              URLParams
-            />
-            <SingleDataList
-              componentId='CampusLocationAggregate'
-              dataField='repository.keyword'
-              title='Campus Location'
-              filterLabel='Campus Location'
-              showSearch={false}
-              URLParams
-              data={
-                [{
-                  label: 'Rare Books and Special Collections',
-                  value: 'SPEC RBSC',
-                }, {
-                  label: 'Snite Museum of Art',
-                  value: 'SNITE',
-                }, {
-                  label: 'University Archives',
-                  value: 'ARCHIVES',
-                }]
-              }
-              react={{
-                'and': components,
-              }}
-            />
-            <MultiDropdownList
-              componentId='LanguageListAggregate'
-              dataField='language.keyword'
-              title='Language'
-              sortBy='count'
-              filterLabel='Language'
-              showSearch={false}
-              react={{
-                'and': components,
-              }}
-              URLParams
-            />
-          </React.Fragment>
-        }
-      >
-        <ReactiveList
-          componentId='SearchResult'
-          dataField={'title'}
-          react={{
-            'and': components,
-          }}
-          excludeFields={['fulltext']}
-          size={48}
-          loader={<Loading />}
-          scrollOnChange
-          infiniteScroll={false}
-          pagination
-          renderNoResults={() => (<div>No matches could be found</div>)}
-          render={({ data, error, loading, ...rest }) => (
-            <ResponsiveGridList measureBeforeMount>
-              {
-                data.map(res => (
-                  <div key={res['_id']}>
-                    <Card
-                      label={res.title}
-                      image={res.thumbnail}
-                      target={res.url}
-                      location={location}
-                      referal={{ type: 'search', query: location.search }}
-                    >
-                      <div className='description'>{res.description}</div>
-                      <div>{res.creator}</div>
-                    </Card>
-                  </div>
-                )
-                )
-              }
-            </ResponsiveGridList>
-          )}
-        />
-      </Layout>
-    </ReactiveBase>
-  )
+const SearchPage = ({ data, location }) => {
+  return <Search
+    searchBase={data.site.siteMetadata.searchBase}
+    location={location}
+  />
 }
 
 SearchPage.propTypes = {
-  location: PropTypes.object,
+  data: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
 }
-
-const mapStateToProps = (state) => {
-  return { ...state }
-}
-
-const mapDispatchToProps = dispatch => {
-  return { dispatch }
-}
-
-export const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const searchBase = ownProps.data.site.siteMetadata.primoSearchBaseURL
-  const values = queryString.parse(ownProps.location.search)
-  if (shouldDispatchSearch(stateProps.searchReducer, values.terms, stateProps.searchReducer.page, values.page, values.perpage)) {
-    dispatchProps.dispatch(
-      submitSearch(searchBase, values.perpage, values.terms, values.page || 1)
-    )
-  }
-  return { ...stateProps, ...dispatchProps, ...ownProps }
-}
-
-export const shouldDispatchSearch = (searchReducer, terms, page, targetPage, perpage) => {
-  // Not currently fetching
-  // Has some terms
-  // Current page of results is changing or terms are changing
-  return (
-    searchReducer.status !== STATUS_SEARCH_FETCHING &&
-    terms &&
-    (
-      parseInt(page, 10) !== parseInt(targetPage, 10) ||
-      searchReducer.terms !== terms ||
-      searchReducer.perpage !== parseInt(perpage, 10)
-    )
-  )
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-  mergeProps
-)(SearchPage)
+export default SearchPage
 
 export const query = graphql`
   query {
     site {
       siteMetadata {
-        primoSearchBaseURL
+        searchBase {
+          app
+          url
+        }
       }
     }
   }


### PR DESCRIPTION
* Add grid/list display toggle to new Search page
* Start to componentize new Search page
* Some unit tests, because why not?
* Move search base information into `gatsby-config.js`