### PR TITLE
MEL-499 Remove Branding Bar

### DIFF
--- a/content/configuration.js
+++ b/content/configuration.js
@@ -20,6 +20,7 @@ module.exports = {
     },
 
     // branding
+    useBrandBar: false,
     headerColor: themeColor,
     institutionURL: `http://nd.edu`,
     institutionLabel: `University of Notre Dame`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -11,6 +11,7 @@ module.exports = {
   // primoSearchBaseURL
   // googleMapApiURL
   // searchBase
+  // useBrandBar
   // headerColor
   // institutionURL
   // institutionLabel,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -121,3 +121,42 @@ exports.createPages = ({ graphql, actions }) => {
 
   // non manifest tags
 }
+
+// predefine stuff we expect from configuration.js
+exports.sourceNodes = ({ actions }) => {
+  const { createTypes } = actions
+
+  const typeDefs = `
+  type searchBase {
+    app: String
+    url: String
+  }
+  type menuItems {
+    id: String
+    label: String
+    link: String
+  }
+  type menus {
+    id: String
+    label: String
+    items: [menuItems]
+  }
+  type SiteMetadata implements Node {
+    universalViewerBaseURL: String
+    googleMapApiURL: String
+    searchBase: searchBase
+    useBrandBar: Boolean
+    headerColor: String
+    institutionURL: String
+    institutionLabel: String
+    departmentURL: String
+    departmentLabel: String
+    footerText: String
+    menus: [menus]
+  }
+  type Site implements Node {
+    siteMetadata: SiteMetadata
+  }
+  `
+  createTypes(typeDefs)
+}

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -141,7 +141,7 @@ exports.sourceNodes = ({ actions }) => {
     label: String
     items: [menuItems]
   }
-  type SiteMetadata implements Node {
+  type SiteMetadata {
     universalViewerBaseURL: String
     googleMapApiURL: String
     searchBase: searchBase

--- a/src/components/Layout/PageWrapper/BrandingHeader/index.js
+++ b/src/components/Layout/PageWrapper/BrandingHeader/index.js
@@ -5,16 +5,20 @@ import LinkedLogo from './LinkedLogo'
 import style from './style.module.css'
 
 export const BrandingHeader = ({ data }) => {
-  const departmentLogo = getLogoURL(data.allFile.edges, 'departmentLogo')
-  const institutionLogo = getLogoURL(data.allFile.edges, 'institutionLogo')
-
   const {
     institutionURL,
     institutionLabel,
     departmentURL,
     departmentLabel,
     headerColor,
+    useBrandBar,
   } = data.site.siteMetadata
+
+  if (!useBrandBar) {
+    return null
+  }
+  const departmentLogo = getLogoURL(data.allFile.edges, 'departmentLogo')
+  const institutionLogo = getLogoURL(data.allFile.edges, 'institutionLogo')
   return (
     <header
       className={style.wrapper}
@@ -56,6 +60,7 @@ export default () => {
       query {
         site {
           siteMetadata {
+            useBrandBar
             institutionURL
             institutionLabel
             departmentURL

--- a/src/components/Layout/PageWrapper/BrandingHeader/test.js
+++ b/src/components/Layout/PageWrapper/BrandingHeader/test.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { BrandingHeader } from './'
+import LinkedLogo from './LinkedLogo'
+
+describe('BrandingHeader', () => {
+  test('name brand', () => {
+    const data = {
+      allFile: {
+        edges: [
+          {
+            node: {
+              name: 'departmentLogo',
+              publicURL: '/pic1.jpg',
+            },
+          },
+          {
+            node: {
+              name: 'institutionLogo',
+              publicURL: '/pic2.jpg',
+            },
+          },
+        ],
+      },
+      site: {
+        siteMetadata: {
+          institutionURL: 'http://test.org',
+          institutionLabel: 'inst label',
+          departmentURL: 'http://test.com',
+          departmentLabel: 'dept label',
+          headerColor: 'green',
+          useBrandBar: true,
+        },
+      },
+    }
+    const wrapper = shallow(<BrandingHeader data={data} />)
+    console.log(wrapper.debug())
+    expect(wrapper.find('.wrapper').exists()).toBeTruthy()
+    expect(wrapper.find(LinkedLogo).length).toEqual(2)
+  })
+  test('brand x', () => {
+    const data = {
+      site: {
+        siteMetadata: {
+        },
+      },
+    }
+    const wrapper = shallow(<BrandingHeader data={data} />)
+    expect(wrapper.find('.wrapper').exists()).toBeFalsy()
+  })
+})

--- a/src/components/Layout/PageWrapper/BrandingHeader/test.js
+++ b/src/components/Layout/PageWrapper/BrandingHeader/test.js
@@ -34,7 +34,6 @@ describe('BrandingHeader', () => {
       },
     }
     const wrapper = shallow(<BrandingHeader data={data} />)
-    console.log(wrapper.debug())
     expect(wrapper.find('.wrapper').exists()).toBeTruthy()
     expect(wrapper.find(LinkedLogo).length).toEqual(2)
   })


### PR DESCRIPTION
* Provide option to remove brand bar in `Site.SiteMetaData` and respect that option in the BrandingHeader component.
* Set `useBrandBar: false` in `configuration.js` .
* Add some typeDefs to predefine some GraphQL stuff we're expecting to use.