### PR TITLE
Change all page to be more like a sitemap

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/assets/icons/svg/mirador-24px.svg
+++ b/@ndlib/gatsby-theme-marble/src/assets/icons/svg/mirador-24px.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="24px" height="24px" viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;}
+</style>
+<path d="M10,13.5h5V5h-5V13.5z M4,18h5V5H4V18z M16,5v13h5V5H16z"/>
+<path class="st0" d="M0,0h24v24H0V0z"/>
+</svg>

--- a/@ndlib/gatsby-theme-marble/src/pages/all.js
+++ b/@ndlib/gatsby-theme-marble/src/pages/all.js
@@ -1,27 +1,71 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { graphql } from 'gatsby'
+import Layout from 'components/Layout'
+import Seo from 'components/Internal/Seo'
 import Link from 'components/Internal/Link'
 
 export const AllPage = ({
   data: {
     allMarkdownRemark: { edges },
   },
+  location,
 }) => {
-  const Posts = edges
-    .filter(edge => !!edge.node.frontmatter.slug.match(/item/)) // You can filter your posts based on some criteria
+  const posts = (type) => edges
+    // eslint-disable-next-line complexity
+    .filter(edge => {
+      // You can filter your posts based on some criteria
+      switch (type) {
+        case 'item':
+          return !!edge.node.frontmatter.slug.match(/item\//)
+        case 'collection':
+          return !!edge.node.frontmatter.slug.match(/collection\//)
+        case 'browse':
+          return !!edge.node.frontmatter.slug.match(/browse\//)
+        default:
+          return !edge.node.frontmatter.slug.match(/item\//) && !edge.node.frontmatter.slug.match(/collection\//) &&
+          !edge.node.frontmatter.slug.match(/browse\//) && edge.node.frontmatter.title
+      }
+    })
+    .sort((a, b) => {
+      const cleanA = a.node.frontmatter.title.replace('"', '')
+      const cleanB = b.node.frontmatter.title.replace('"', '')
+      if (cleanA < cleanB) {
+        return -1
+      }
+      if (cleanA > cleanB) {
+        return 1
+      }
+      return 0
+    })
     .map(edge => <li key={edge.node.id}><Link to={edge.node.frontmatter.slug} >{edge.node.frontmatter.title}</Link></li>)
 
   return (
-    <div>
-      <h1>All Current items</h1>
-      <ul>{Posts}</ul>
-    </div>
+    <Layout
+      title='Sitemap'
+      location={location}
+    >
+      <Seo
+        data={{}}
+        location={location}
+      />
+      <h2>Collections</h2>
+      <ul>{posts('collection')}</ul>
+      <h2>Items</h2>
+      <ul>{posts('item')}</ul>
+      {
+        // <h2>Browse Pages</h2>
+        // <ul>{posts('browse')}</ul>
+      }
+      <h2>Other Content</h2>
+      <ul>{posts()}</ul>
+    </Layout>
   )
 }
 
 AllPage.propTypes = {
   data: PropTypes.object.isRequired,
+  location: PropTypes.object,
 }
 
 export default AllPage

--- a/site/content/menus.js
+++ b/site/content/menus.js
@@ -49,6 +49,11 @@ module.exports = [
         label: 'Help',
         link: '/help',
       },
+      {
+        id: 'footer-sitemap',
+        label: 'Site Map',
+        link: '/sitemap',
+      },
     ],
   },
   {

--- a/site/src/pages/sitemap.js
+++ b/site/src/pages/sitemap.js
@@ -4,6 +4,7 @@ import { graphql } from 'gatsby'
 import Layout from 'components/Layout'
 import Seo from 'components/Internal/Seo'
 import Link from 'components/Internal/Link'
+import miradorIcon from 'assets/icons/svg/mirador-24px.svg'
 
 export const AllPage = ({
   data: {
@@ -21,10 +22,11 @@ export const AllPage = ({
         case 'collection':
           return !!edge.node.frontmatter.slug.match(/collection\//)
         case 'browse':
-          return !!edge.node.frontmatter.slug.match(/browse\//)
+          return !!edge.node.frontmatter.slug.match(/browse/)
         default:
           return !edge.node.frontmatter.slug.match(/item\//) && !edge.node.frontmatter.slug.match(/collection\//) &&
-          !edge.node.frontmatter.slug.match(/browse\//) && edge.node.frontmatter.title
+          !edge.node.frontmatter.slug.match(/browse/) &&
+            !edge.node.frontmatter.slug.match(/404.html/) && edge.node.frontmatter.title
       }
     })
     .sort((a, b) => {
@@ -38,7 +40,31 @@ export const AllPage = ({
       }
       return 0
     })
-    .map(edge => <li key={edge.node.id}><Link to={edge.node.frontmatter.slug} >{edge.node.frontmatter.title}</Link></li>)
+    .map(edge => {
+      return (
+        <li key={edge.node.id}>
+          <Link to={edge.node.frontmatter.slug} >{edge.node.frontmatter.title}</Link>
+          {
+            edge.node.frontmatter.slug.match(/item\//) ? (
+              <React.Fragment>
+                <span>&nbsp;</span>
+                <Link to={`${edge.node.frontmatter.slug}/mirador`} >
+                  <img
+                    src={miradorIcon}
+                    alt='Open in Mirador'
+                    style={{
+                      height: '16px',
+                      width: '16px',
+                      verticalAlign: 'text-bottom',
+                    }}
+                  />
+                </Link>
+              </React.Fragment>
+            ) : null
+          }
+        </li>
+      )
+    })
 
   return (
     <Layout
@@ -53,10 +79,8 @@ export const AllPage = ({
       <ul>{posts('collection')}</ul>
       <h2>Items</h2>
       <ul>{posts('item')}</ul>
-      {
-        // <h2>Browse Pages</h2>
-        // <ul>{posts('browse')}</ul>
-      }
+      <h2>Browse Pages</h2>
+      <ul>{posts('browse')}</ul>
       <h2>Other Content</h2>
       <ul>{posts()}</ul>
     </Layout>
@@ -69,7 +93,7 @@ AllPage.propTypes = {
 }
 
 export default AllPage
-export const pageQuery = graphql`
+export const query = graphql`
   query {
     allMarkdownRemark {
       edges {


### PR DESCRIPTION
* Add basic `Layout` wrapper and styling.
* Move url to `/sitemap` from `/all`
* Display `collections`, `items`, `browse pages`, and "other things" in separate sections.
* add mirador links to items
* move code to `/site`
* add link to `/sitemap` in footer