### PR TITLE
fix bug with extra characters on library dates

### DIFF
--- a/scripts/gatsby-source-iiif/src/realDatesFromCatalogedDates/index.js
+++ b/scripts/gatsby-source-iiif/src/realDatesFromCatalogedDates/index.js
@@ -103,7 +103,8 @@ const isDashedQuestionMarkDate = (d) => {
 
 // replace all the dashed question marks with the range
 const extractDashedQuestionMarkDate = (d) => {
-  return [d.replace(/[-]{2}\?/, '00').replace(/[-]\?/, '0'), d.replace(/[-]{2}\?/, '99').replace(/[-]\?/, '9')]
+  // replace -- with 00 or - with 0 and remove all non integer characters.
+  return [d.replace(/[-]{2}\?/, '00').replace(/[-]\?/, '0').replace(/[^0-9]+/g, ''), d.replace(/[-]{2}\?/, '99').replace(/[-]\?/, '9').replace(/[^0-9]+/g, '')]
 }
 
 // some items come with ordinal numbers as the dates.

--- a/scripts/gatsby-source-iiif/src/realDatesFromCatalogedDates/test.js
+++ b/scripts/gatsby-source-iiif/src/realDatesFromCatalogedDates/test.js
@@ -4,6 +4,7 @@ test('takes a string year(s) and gets a highest and lowest values for it', () =>
   [
     ['1790-1890', 1790, 1890],
     ['19--?', 1900, 1999],
+    ['[19--?].', 1900, 1999],
     ['1745-1750; 1780; 1790-1800', 1745, 1800],
     ['ca. 1899-1900', 1899, 1900],
     [1342, 1342, 1342],
@@ -53,6 +54,7 @@ test('takes a string year and gets a tag for it', () => {
     ['1937.', ['20th Century']],
     ['ca. 1899-1900', ['19th Century', '20th Century']],
     ['19--?', ['20th Century']],
+    ['[19--?].', ['20th Century']],
     ['176-?', ['18th Century']],
     [1342, ['14th Century']],
     ['1900', ['20th Century']],


### PR DESCRIPTION
library dates actually have things like 

'[19--?].'  in them.  