### PR TITLE
MARBLE-836 Add Download UI

### DIFF
--- a/@ndlib/gatsby-theme-marble/package.json
+++ b/@ndlib/gatsby-theme-marble/package.json
@@ -56,6 +56,7 @@
     "jest": "^24.7.1",
     "jest-environment-enzyme": "^7.0.2",
     "jest-enzyme": "^7.0.2",
+    "js-file-downloader": "^1.1.7",
     "lodash.merge": "^4.6.2",
     "md5": "^2.2.1",
     "mirador": "3.0.0-beta.6",

--- a/@ndlib/gatsby-theme-marble/src/components/Internal/ActionModal/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Internal/ActionModal/index.js
@@ -27,8 +27,7 @@ const ActionModal = ({
       onRequestClose={closeFunc}
       shouldCloseOnOverlayClick
     >
-      <div
-        sx={sx.wrapper}>
+      <div sx={sx.wrapper}>
         <h1
           sx={sx.heading}
         >{contentLabel}</h1>
@@ -54,8 +53,7 @@ const ActionModal = ({
         </button>
       </div>
       <BaseStyles>
-        <div
-          sx={sx.content}>{ children }</div>
+        <div sx={sx.content}>{ children }</div>
       </BaseStyles>
     </ReactModal>
   )
@@ -86,6 +84,8 @@ export const modalStyle = (fullscreen) => {
       right: 'auto',
       bottom: fullscreen ? '40px' : 'auto',
       marginRight: '-50%',
+      position: 'absolute',
+      overflow: 'hidden',
       height: fullscreen ? 'calc(100vh - 80px)' : 'auto',
       width: fullscreen ? '95vw' : '500px',
       maxWidth: '95vw',

--- a/@ndlib/gatsby-theme-marble/src/components/Internal/ActionModal/sx.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Internal/ActionModal/sx.js
@@ -3,7 +3,9 @@ module.exports = {
     backgroundColor: 'primary',
     display: 'block',
     overflow: 'hidden',
+    position: 'absolute',
     width: '100%',
+    zIndex: '1',
   },
   heading: {
     color: 'background',
@@ -13,6 +15,7 @@ module.exports = {
     lineHeight: '1.5rem',
     margin: '0',
     padding: '1rem',
+    position: 'fixed',
   },
   button: {
     backgroundColor: 'primary',
@@ -29,6 +32,11 @@ module.exports = {
     verticalAlign: 'middle',
   },
   content: {
+    maxHeight: 'calc(100vh - 80px - 3rem)',
+    marginTop: '3rem',
     padding: '1rem',
+    overflowX: 'hidden',
+    overflowY: 'scroll',
+    position: 'relative',
   },
 }

--- a/@ndlib/gatsby-theme-marble/src/components/Internal/Seo/SeoContent/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Internal/Seo/SeoContent/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Helmet from 'react-helmet'
 import CanonicalLink from './CanonicalLink'
-import SchemaLink from './SchemaLink'
+// import SchemaLink from './SchemaLink'
 import MetaTagGroup from './MetaTagGroup'
 import { getOpenGraph, getTwitter } from './data'
 
@@ -16,7 +16,7 @@ export const SeoContent = ({
   siteTitle,
   siteUrl,
   noIndex,
-  seeAlso,
+  // seeAlso,
 }) => {
   const openGraph = getOpenGraph(title, description, image)
   const twitter = getTwitter(author, title, description, image)

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/Copyright/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/Copyright/index.js
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import PropTypes from 'prop-types'
+import { BaseStyles, jsx } from 'theme-ui'
+import sx from './sx'
+export const Copyright = ({ text }) => {
+  return (
+    <BaseStyles>
+      <div sx={sx.wrapper}>{text}</div>
+    </BaseStyles>
+  )
+}
+
+Copyright.propTypes = {
+  text: PropTypes.string,
+}
+
+Copyright.defaultProps = {
+  text: `© ${new Date().getFullYear()}`,
+}
+
+export default Copyright

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/Copyright/sx.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/Copyright/sx.js
@@ -1,0 +1,9 @@
+module.exports = {
+  wrapper: {
+    backgroundColor: 'background',
+    fontSize: '.8rem',
+    marginBottom: '.5rem',
+    textAlign: 'center',
+    width: '100%',
+  },
+}

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadCitation/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadCitation/index.js
@@ -1,0 +1,15 @@
+/** @jsx jsx */
+import PropTypes from 'prop-types'
+import { jsx } from 'theme-ui'
+
+const DownloadCitation = ({ iiifManifest }) => {
+  return (
+    <div sx={{}}>Citation for <code>{iiifManifest.slug}</code> TBD.</div>
+  )
+}
+
+DownloadCitation.propTypes = {
+  iiifManifest: PropTypes.object.isRequired,
+}
+
+export default DownloadCitation

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImagePager/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImagePager/index.js
@@ -1,0 +1,54 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
+import MaterialButton from 'components/Internal/MaterialButton'
+
+const ImagePager = ({ sxStyle, images, selected, setSelected }) => {
+  if (images.length < 2) {
+    return null
+  }
+  return (
+    <div sx={sxStyle.controlWrapper}>
+      <MaterialButton
+        onClick={() => {
+          setSelected(selected - 1)
+        }}
+        disabled={selected === 0}
+      >&lt;</MaterialButton>
+      <select
+        onChange={(event) => {
+          setSelected(parseInt(event.target.value, 10))
+        }}
+        onBlur={() => {}}
+        value={selected}
+        sx={sxStyle.select}
+      >
+        {
+          images.map((image, index) => {
+            return (
+              <option
+                value={index}
+                key={index}
+              >{index + 1}</option>
+            )
+          })
+        }
+      </select>
+      <MaterialButton
+        onClick={() => {
+          setSelected(selected + 1)
+        }}
+        disabled={selected === images.length - 1}
+      >&gt;</MaterialButton>
+    </div>
+  )
+}
+
+ImagePager.propTypes = {
+  sxStyle: PropTypes.object.isRequired,
+  images: PropTypes.array.isRequired,
+  selected: PropTypes.number.isRequired,
+  setSelected: PropTypes.func.isRequired,
+}
+
+export default ImagePager

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImagePager/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImagePager/test.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+import ImagePager from './'
+import MaterialButton from 'components/Internal/MaterialButton'
+
+describe('ImagePager', () => {
+  const sxStyle = {}
+  const selected = 0
+  const setSelected = jest.fn()
+
+  test('no images', () => {
+    const props = {
+      sxStyle: sxStyle,
+      images: [],
+      selected: selected,
+      setSelected: setSelected,
+    }
+    const wrapper = mount(<ImagePager {...props} />)
+    expect(wrapper.find('div').exists()).toBeFalsy()
+  })
+
+  test('1 image', () => {
+    const props = {
+      sxStyle: sxStyle,
+      images: ['image 1.jpg'],
+      selected: selected,
+      setSelected: setSelected,
+    }
+    const wrapper = mount(<ImagePager {...props} />)
+    expect(wrapper.find('div').exists()).toBeFalsy()
+  })
+
+  test('2 or more images', () => {
+    const props = {
+      sxStyle: sxStyle,
+      images: ['image 1.jpg', 'image 2.jpg', 'image 2.jpg'],
+      selected: 1,
+      setSelected: setSelected,
+    }
+    const wrapper = mount(<ImagePager {...props} />)
+    expect(wrapper.find('div').exists()).toBeTruthy()
+
+    // test select
+    act(() => {
+      const e = {
+        target: {
+          value: '32',
+        },
+      }
+      wrapper.find('select').props().onChange(e)
+      expect(setSelected).toHaveBeenCalledWith(32)
+    })
+    // test next
+    act(() => {
+      wrapper.find(MaterialButton).at(1).props().onClick()
+      expect(setSelected).toHaveBeenCalledWith(2)
+    })
+    // test previous
+    act(() => {
+      wrapper.find(MaterialButton).at(0).props().onClick()
+      expect(setSelected).toHaveBeenCalledWith(0)
+    })
+  })
+
+  test('disabled buttons', () => {
+    const props = {
+      sxStyle: sxStyle,
+      images: ['image 1.jpg', 'image 2.jpg'],
+      selected: 0,
+      setSelected: setSelected,
+    }
+    let wrapper = mount(<ImagePager {...props} />)
+    expect(wrapper.find(MaterialButton).at(0).props().disabled).toEqual(true)
+    expect(wrapper.find(MaterialButton).at(1).props().disabled).toEqual(false)
+
+    props.selected = 1
+    wrapper = mount(<ImagePager {...props} />)
+    expect(wrapper.find(MaterialButton).at(0).props().disabled).toEqual(false)
+    expect(wrapper.find(MaterialButton).at(1).props().disabled).toEqual(true)
+  })
+})

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImagePreview/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImagePreview/index.js
@@ -1,0 +1,23 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
+
+const ImagePreview = ({ sxStyle, images, selected }) => {
+  return (
+    <picture sx={sxStyle.wrapper}>
+      <img
+        src={images[selected].replace('full/full', 'full/,600')}
+        alt='Preview'
+        sx={sxStyle.image}
+      />
+    </picture>
+  )
+}
+
+ImagePreview.propTypes = {
+  sxStyle: PropTypes.object.isRequired,
+  images: PropTypes.array.isRequired,
+  selected: PropTypes.number.isRequired,
+}
+
+export default ImagePreview

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImagePreview/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImagePreview/test.js
@@ -1,0 +1,14 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import ImagePreview from './'
+
+test('ImagePreview', () => {
+  const props = {
+    sxStyle: {},
+    images: ['test/full/full/image.png'],
+    selected: 0,
+  }
+  const wrapper = mount(<ImagePreview {...props} />)
+  expect(wrapper.find('picture').exists()).toBeTruthy()
+  expect(wrapper.find('img').props().src).toEqual('test/full/,600/image.png')
+})

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImageSettings/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImageSettings/index.js
@@ -1,0 +1,47 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
+
+const ImageSettings = ({ sxStyle, size, setSize, format, setFormat }) => {
+  return (
+    <div sx={sxStyle.controlWrapper}>
+      <label htmlFor='size'>Size:</label>
+      <select
+        name='size'
+        onChange={(event) => {
+          setSize(event.target.value)
+        }}
+        onBlur={() => {}}
+        value={size}
+        sx={sxStyle.select}
+      >
+        <option value='full'>100%</option>
+        <option value='pct:50'>50%</option>
+        <option value='pct:25'>25%</option>
+      </select>
+      <label htmlFor='fromat'>Format:</label>
+      <select
+        name='format'
+        onChange={(event) => {
+          setFormat(event.target.value)
+        }}
+        onBlur={() => {}}
+        value={format}
+        sx={sxStyle.select}
+      >
+        <option value='jpg'>.jpg</option>
+        <option value='png'>.png</option>
+      </select>
+    </div>
+  )
+}
+
+ImageSettings.propTypes = {
+  sxStyle: PropTypes.object.isRequired,
+  size: PropTypes.string.isRequired,
+  setSize: PropTypes.func.isRequired,
+  format: PropTypes.string.isRequired,
+  setFormat: PropTypes.func.isRequired,
+}
+
+export default ImageSettings

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImageSettings/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/ImageSettings/test.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+import ImageSettings from './'
+
+describe('ImageSettings', () => {
+  const props = {
+    sxStyle: {},
+    size: 'full',
+    setSize: jest.fn(),
+    format: 'jpg',
+    setFormat: jest.fn(),
+  }
+
+  const wrapper = mount(<ImageSettings {...props} />)
+
+  test('size', () => {
+    act(() => {
+      const e = {
+        target: {
+          value: 'pct:25',
+        },
+      }
+      wrapper.find('select').at(0).props().onChange(e)
+    })
+    expect(props.setSize).toHaveBeenCalledWith('pct:25')
+  })
+
+  test('format', () => {
+    act(() => {
+      const e = {
+        target: {
+          value: 'png',
+        },
+      }
+      wrapper.find('select').at(1).props().onChange(e)
+    })
+    expect(props.setFormat).toHaveBeenCalledWith('png')
+  })
+})

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/index.js
@@ -6,7 +6,7 @@ import ImagePreview from './ImagePreview'
 import ImagePager from './ImagePager'
 import ImageSettings from './ImageSettings'
 import MaterialButton from 'components/Internal/MaterialButton'
-import download from 'utils/download'
+import { download } from 'utils/download'
 import {
   copyrightCanDownload,
   imageUrl,

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/index.js
@@ -1,0 +1,75 @@
+/** @jsx jsx */
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { jsx } from 'theme-ui'
+import ImagePreview from './ImagePreview'
+import ImagePager from './ImagePager'
+import ImageSettings from './ImageSettings'
+import MaterialButton from 'components/Internal/MaterialButton'
+import download from 'utils/download'
+import {
+  copyrightCanDownload,
+  imageUrl,
+  imageName,
+  getImagesFromManifest,
+} from './utils'
+import sx from './sx'
+
+const DownloadImage = ({ iiifManifest }) => {
+  const [images, setImages] = useState([])
+  const [selected, setSelected] = useState(0)
+  const [size, setSize] = useState('full')
+  const [format, setFormat] = useState('jpg')
+
+  useEffect(() => {
+    setImages(getImagesFromManifest(iiifManifest))
+  }, [iiifManifest])
+
+  if (images.length < 1 || !copyrightCanDownload(iiifManifest)) {
+    return (
+      <div sx={sx.wrapper}>
+        <p sx={sx.image}>Image Download Unavailable.</p>
+      </div>
+    )
+  }
+  return (
+    <React.Fragment>
+      <ImagePreview
+        sxStyle={sx}
+        images={images}
+        selected={selected}
+      />
+      <ImagePager
+        sxStyle={sx}
+        images={images}
+        selected={selected}
+        setSelected={setSelected}
+      />
+      <ImageSettings
+        sxStyle={sx}
+        size={size}
+        setSize={setSize}
+        format={format}
+        setFormat={setFormat}
+      />
+      <div sx={sx.controlWrapper}>
+        <MaterialButton
+          onClick={() => {
+            download(
+              imageUrl(images, selected, size, format),
+              imageName(iiifManifest, images, selected, format),
+            )
+          }}
+          primary
+          wide
+        >Download Image</MaterialButton>
+      </div>
+    </React.Fragment>
+  )
+}
+
+DownloadImage.propTypes = {
+  iiifManifest: PropTypes.object.isRequired,
+}
+
+export default DownloadImage

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/sx.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/sx.js
@@ -1,0 +1,35 @@
+module.exports = {
+  wrapper: {
+    backgroundColor: 'gray.1',
+    display: 'flex',
+    height: 'calc(100vh - 390px)',
+    marginBottom: '1rem',
+    maxHeight: '600px',
+    textAlign: 'center',
+    verticalAlign: 'middle',
+    width: '100%',
+  },
+  image: {
+    margin: 'auto',
+    maxHeight: '100%',
+    maxWidth: '100%',
+  },
+  controlWrapper: {
+    marginBottom: '.5rem',
+    textAlign: 'center',
+    width: '100%',
+  },
+  select: {
+    fontSize: '18px',
+    border: '1px solid',
+    borderColor: 'gray.1',
+    backgroundColor: 'background',
+    color: 'gray.4',
+    height: '32px',
+    margin: '0 1rem',
+    padding: '0 2rem',
+    textAlignLast: 'center',
+    WebkitAppearance: 'none',
+    MozAppearance: 'none',
+  },
+}

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/test.js
@@ -1,0 +1,46 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+import DownloadImage from './'
+import ImagePreview from './ImagePreview'
+import ImagePager from './ImagePager'
+import ImageSettings from './ImageSettings'
+import MaterialButton from 'components/Internal/MaterialButton'
+import * as download from 'utils/download'
+
+console.error = jest.fn()
+
+describe('DownloadImage', () => {
+  test('no images', () => {
+    const iiifManifest = {}
+    const wrapper = mount(<DownloadImage iiifManifest={iiifManifest} />)
+    expect(wrapper.find(ImagePreview).exists()).toBeFalsy()
+    expect(wrapper.find(ImagePager).exists()).toBeFalsy()
+    expect(wrapper.find(ImageSettings).exists()).toBeFalsy()
+  })
+
+  test('images', () => {
+    const downloadSpy = jest.spyOn(download, 'download')
+    const iiifManifest = {
+      type: 'manifest',
+      items: [{
+        items: [{
+          items: [{
+            body: {
+              id: 'image.image',
+            },
+          }],
+        }],
+      }],
+    }
+    const images = ['image.image']
+    const wrapper = mount(<DownloadImage iiifManifest={iiifManifest} />)
+    expect(wrapper.find(ImagePreview).props().images).toEqual(images)
+    expect(wrapper.find(ImagePager).props().images).toEqual(images)
+    expect(wrapper.find(ImageSettings).exists()).toBeTruthy()
+    act(() => {
+      wrapper.find(MaterialButton).props().onClick()
+    })
+    expect(downloadSpy).toHaveBeenCalled()
+  })
+})

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/utils.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadImage/utils.js
@@ -1,0 +1,34 @@
+import typy from 'typy'
+import getLanguage from 'utils/getLanguage'
+
+export const copyrightCanDownload = (iiifManifest) => {
+  const lang = getLanguage()
+  const rsLabel = typy(iiifManifest, `requiredStatement.label[${lang}][0]`).safeString
+  const rsValue = typy(iiifManifest, `requiredStatement.value[${lang}][0]`).safeString
+  if (rsLabel.toLowerCase() === 'copyright' && rsValue.toLowerCase() === 'copyright') {
+    return false
+  }
+  return true
+}
+
+export const imageUrl = (images, index, size, format) => {
+  return images[index].replace('full/full', `full/${size}`).replace('default.jpg', `default.${format}`)
+}
+
+export const imageName = (iiifManifest, images, index, format) => {
+  const numDigits = ('' + images.length).length
+  const num = `${index + 1}`.padStart(numDigits, '0')
+  return `${typy(iiifManifest, 'slug').safeString.replace('item/', '')}_${num}.${format}`
+}
+
+export const getImagesFromManifest = (iiifManifest) => {
+  if (typy(iiifManifest, 'type').safeString.toLowerCase() === 'manifest') {
+    return typy(iiifManifest, 'items').safeArray.map(item => {
+      return typy(item, 'items[0].items[0].body.id').safeString
+    })
+  } else {
+    return typy(iiifManifest, 'items').safeArray.map(item => {
+      return typy(item, 'items[0].items[0].items[0].body.id').safeString
+    })
+  }
+}

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadMetadata/AboutIIIF/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadMetadata/AboutIIIF/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+const AboutIIIF = () => {
+  return (
+    <div>
+      <p>
+        <a
+          href='https://iiif.io/'
+          target='_blank'
+          rel='noopener noreferrer'>IIIF or the International Image Interoperability Framework</a>, is an open-source image sharing system.
+      </p>
+    </div>
+  )
+}
+
+export default AboutIIIF

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadMetadata/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadMetadata/index.js
@@ -1,0 +1,28 @@
+/** @jsx jsx */
+import React from 'react'
+import PropTypes from 'prop-types'
+import { jsx } from 'theme-ui'
+import AboutIIIF from './AboutIIIF'
+import MaterialButton from 'components/Internal/MaterialButton'
+import download from 'utils/download'
+
+const DownloadMetadata = ({ iiifManifest }) => {
+  return (
+    <React.Fragment>
+      <AboutIIIF />
+      <MaterialButton
+        onClick={
+          () => download(`${iiifManifest.id}/`, `${iiifManifest.slug.replace('item/', '') || 'manifest'}.json`)
+        }
+        wide
+        primary
+      >Download IIIF Manifest</MaterialButton>
+    </React.Fragment>
+  )
+}
+
+DownloadMetadata.propTypes = {
+  iiifManifest: PropTypes.object.isRequired,
+}
+
+export default DownloadMetadata

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/index.js
@@ -1,10 +1,35 @@
+/** @jsx jsx */
 import React from 'react'
 import PropTypes from 'prop-types'
+import { Styled, jsx } from 'theme-ui'
+import MultiColumn from 'components/Shared/MultiColumn'
+import Column from 'components/Shared/Column'
+import DownloadImage from './DownloadImage'
+import DownloadMetadata from './DownloadMetadata'
+// import DownloadCitation from './DownloadCitation'
+import Copyright from './Copyright'
+import sx from './sx'
 
 const DownloadModalContent = ({ iiifManifest }) => {
   return (
     <React.Fragment>
-      <p>Download Tools for <code>{ iiifManifest.slug }</code>.</p>
+      <MultiColumn columns='2'>
+        <Column>
+          <Styled.h2 sx={sx.header}>Image</Styled.h2>
+          <DownloadImage iiifManifest={iiifManifest} />
+        </Column>
+        <Column>
+          <Styled.h2 sx={sx.header}>Metadata</Styled.h2>
+          <div sx={sx.metadata}>
+            <DownloadMetadata iiifManifest={iiifManifest} />
+          </div>
+          {
+          // <Styled.h2 sx={sx.header}>Citation</Styled.h2>
+          // <DownloadCitation iiifManifest={iiifManifest} />
+          }
+        </Column>
+      </MultiColumn>
+      <Copyright />
     </React.Fragment>
   )
 }
@@ -12,4 +37,5 @@ const DownloadModalContent = ({ iiifManifest }) => {
 DownloadModalContent.propTypes = {
   iiifManifest: PropTypes.object.isRequired,
 }
+
 export default DownloadModalContent

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/sx.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/sx.js
@@ -1,0 +1,8 @@
+module.exports = {
+  header: {
+    marginTop: '0',
+  },
+  metadata: {
+    marginBottom: '2rem',
+  },
+}

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import DownloadModalContent from './'
+import MultiColumn from 'components/Shared/MultiColumn'
+import Column from 'components/Shared/Column'
+import DownloadImage from './DownloadImage'
+import DownloadMetadata from './DownloadMetadata'
+// import DownloadCitation from './DownloadCitation'
+import Copyright from './Copyright'
+
+test('DownloadModalContent', () => {
+  const iiifManifest = {}
+  const wrapper = mount(<DownloadModalContent iiifManifest={iiifManifest} />)
+  expect(wrapper.find(MultiColumn).props().columns).toEqual('2')
+  expect(wrapper.find(Column).length).toEqual(2)
+  expect(wrapper.find(DownloadImage).props().iiifManifest).toEqual(iiifManifest)
+  expect(wrapper.find(DownloadMetadata).props().iiifManifest).toEqual(iiifManifest)
+  // expect(wrapper.find(DownloadCitation).props().iiifManifest).toEqual(iiifManifest)
+  expect(wrapper.find(Copyright).exists()).toBeTruthy()
+})

--- a/@ndlib/gatsby-theme-marble/src/templates/markdownTemplate.js
+++ b/@ndlib/gatsby-theme-marble/src/templates/markdownTemplate.js
@@ -190,6 +190,9 @@ export const query = graphql`
               ...iiifJsonItemFragment
               items {
                 ...iiifJsonItemFragment
+                items {
+                  ...iiifJsonItemFragment
+                }
               }
             }
           }

--- a/@ndlib/gatsby-theme-marble/src/utils/download.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/download.js
@@ -1,0 +1,21 @@
+import Downloader from 'js-file-downloader'
+export const download = (
+  url,
+  filename,
+  callback = () => {},
+  errorFunc = (e) => {
+    console.error(e)
+  },
+) => {
+  new Downloader({
+    url: url,
+    filename: filename,
+  })
+    .then(() => {
+      callback()
+    })
+    .catch((e) => {
+      errorFunc(e)
+    })
+}
+export default download

--- a/site/content/markdown/browse.md
+++ b/site/content/markdown/browse.md
@@ -30,55 +30,55 @@ components:
               - label: "label"
                 value: "14th Century"
               - label: "target"
-                value: "search?timeperiod[0]=14th%20Century"
+                value: "/search?timeperiod[0]=14th%20Century"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "15th Century"
                 - label: "target"
-                  value: "search?timeperiod[0]=15th%20Century"
+                  value: "/search?timeperiod[0]=15th%20Century"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "16th Century"
                 - label: "target"
-                  value: "search?timeperiod[0]=16th%20Century"
+                  value: "/search?timeperiod[0]=16th%20Century"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "17th Century"
                 - label: "target"
-                  value: "search?timeperiod[0]=17th%20Century"
+                  value: "/search?timeperiod[0]=17th%20Century"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "18th Century"
                 - label: "target"
-                  value: "search?timeperiod[0]=18th%20Century"
+                  value: "/search?timeperiod[0]=18th%20Century"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "19th Century"
                 - label: "target"
-                  value: "search?timeperiod[0]=19th%20Century"
+                  value: "/search?timeperiod[0]=19th%20Century"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "20th Century"
                 - label: "target"
-                  value: "search?timeperiod[0]=20th%20Century"
+                  value: "/search?timeperiod[0]=20th%20Century"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "21st Century"
                 - label: "target"
-                  value: "search?timeperiod[0]=21st%20Century"
+                  value: "/search?timeperiod[0]=21st%20Century"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "undated"
                 - label: "target"
-                  value: "search?timeperiod[0]=undated"
+                  value: "/search?timeperiod[0]=undated"
 - component: MultiColumn
   props:
     - label: 'columns'
@@ -102,25 +102,25 @@ components:
                 - label: "label"
                   value: "Paintings"
                 - label: "target"
-                  value: "search?format[0]=Paintings"
+                  value: "/search?format[0]=Paintings"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "Photographs"
                 - label: "target"
-                  value: "search?format[0]=Photographs"
+                  value: "/search?format[0]=Photographs"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "Prints"
                 - label: "target"
-                  value: "search?format[0]=Prints"
+                  value: "/search?format[0]=Prints"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "Sculpture"
                 - label: "target"
-                  value: "search?place[0]=Sculpture"
+                  value: "/search?place[0]=Sculpture"
 - component: MultiColumn
   props:
     - label: 'columns'
@@ -144,13 +144,13 @@ components:
                 - label: "label"
                   value: "Rare Books and Special Collections"
                 - label: "target"
-                  value: "search?campuslocation[0]=Rare%20Books%20and%20Special%20Collections"
+                  value: "/search?campuslocation[0]=Rare%20Books%20and%20Special%20Collections"
             - component: MiniCard
               props:
                 - label: "label"
                   value: "Snite Museum of Art"
                 - label: "target"
-                  value: "search?campuslocation[0]=Snite%20Museum%20of%20Art"
+                  value: "/search?campuslocation[0]=Snite%20Museum%20of%20Art"
 ---
 
 Browse all the amazing content.

--- a/site/src/@ndlib/gatsby-theme-marble/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/Copyright/index.js
+++ b/site/src/@ndlib/gatsby-theme-marble/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/Copyright/index.js
@@ -1,0 +1,13 @@
+/** @jsx jsx */
+import { BaseStyles, jsx } from 'theme-ui'
+import Link from '@ndlib/gatsby-theme-marble/src/components/Internal/Link'
+import sx from '@ndlib/gatsby-theme-marble/src/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/Copyright/sx'
+export const Copyright = () => {
+  return (
+    <BaseStyles>
+      <div sx={sx.wrapper}>© {new Date().getFullYear()} University of Notre Dame, unless otherwise noted. <Link to='help/copyright-and-permissions'>Copyright and permissions</Link>.</div>
+    </BaseStyles>
+  )
+}
+
+export default Copyright

--- a/site/src/@ndlib/gatsby-theme-marble/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadMetadata/AboutIIIF/index.js
+++ b/site/src/@ndlib/gatsby-theme-marble/components/Shared/ActionButtonGroup/DownloadButton/DownloadModalContent/DownloadMetadata/AboutIIIF/index.js
@@ -1,0 +1,24 @@
+import React from 'react'
+
+const AboutIIIF = () => {
+  return (
+    <div>
+      <p>
+        <a
+          href='https://iiif.io/'
+          target='_blank'
+          rel='noopener noreferrer'>IIIF or the International Image Interoperability Framework
+        </a>
+        , is an open-source image sharing system. Learn more about the use of&nbsp;
+        <a
+          href='https://sites.nd.edu/marble/iiif-at-notre-dame-or-the-heart-of-marble/'
+          target='_blank'
+          rel='noopener noreferrer'>
+          IIIF at Notre Dame.
+        </a>
+      </p>
+    </div>
+  )
+}
+
+export default AboutIIIF

--- a/yarn.lock
+++ b/yarn.lock
@@ -9625,6 +9625,11 @@ js-cookie@2.2.0:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
   integrity sha1-Gywnmm7s44ChIWi5JIUmWzWx7/s=
 
+js-file-downloader@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/js-file-downloader/-/js-file-downloader-1.1.7.tgz#c53a0816b6ee3552f9c9220096c491cf38bfce76"
+  integrity sha512-yFRu46S4vRUUvQI7eUrSxw2MzSgOSwCSnzNRHyoKNIWzbOfDk6WHKfkfvv93BxgX21wr9MwA5p4jwssBJ9GdAg==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
* Image download:
  * Image preview
  * Pager to select image if there are multiple
  * Image download size and format options
  * Disabled download when item has no images or if under copyright.
* Metadata download:
  * Description of IIIF and links to more information
  * Direct download for IIIF manifest file
* Stub component for Citation
* Adds `js-file-downloader` run `yarn` after pulling.

One image:
![Screen Shot 2020-05-08 at 12 28 15 PM](https://user-images.githubusercontent.com/416559/81426685-89362300-9127-11ea-9f57-52c900712940.png)

Multiple Images for item:
![Screen Shot 2020-05-08 at 12 29 02 PM](https://user-images.githubusercontent.com/416559/81426714-94894e80-9127-11ea-8d82-e51d5b6e01e4.png)

Collections of multiple items:
![Screen Shot 2020-05-08 at 12 28 41 PM](https://user-images.githubusercontent.com/416559/81426737-9d7a2000-9127-11ea-8c4c-1f478125d238.png)

 Copyrighted image:
![Screen Shot 2020-05-08 at 12 28 51 PM](https://user-images.githubusercontent.com/416559/81426773-a965e200-9127-11ea-826c-a0c529274d4f.png)
