### PR TITLE
MARBLE-876 Bugfix Browse page with url hash

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Layout/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Layout/index.js
@@ -1,6 +1,7 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { Layout as ThemeLayout } from 'theme-ui'
+import queryString from 'query-string'
 import AuthWrapper from './AuthWrapper'
 import PrivateRoute from './PrivateRoute'
 import PageWrapper from './PageWrapper'
@@ -17,8 +18,14 @@ const Layout = ({
   requireLogin, // bool to test login
   location,
 }) => {
+  const [qs] = useState(queryString.parse(location.search) || {})
   useEffect(() => {
-    document.querySelector('#gatsby-focus-wrapper').scrollTop = 0
+    const scrollTo = document.querySelector(`#${qs.scrollto}`)
+    if (scrollTo) {
+      scrollTo.scrollIntoView()
+    } else {
+      document.querySelector('#gatsby-focus-wrapper').scrollTop = 0
+    }
   })
 
   return (

--- a/site/content/markdown/browse.md
+++ b/site/content/markdown/browse.md
@@ -17,7 +17,7 @@ components:
         - component: MarkdownHtmlContent
           props:
             - label: "html"
-              value: "<div><a name='date'></a><h2>Browse By Date</h2></div>"
+              value: "<div id='date'><h2>Browse By Date</h2></div>"
     - component: Column
       props:
         - label: 'colSpan'
@@ -89,7 +89,7 @@ components:
         - component: MarkdownHtmlContent
           props:
             - label: "html"
-              value: "<div><a name='format'></a><h2>Browse By Format</h2></div>"
+              value: "<div id='format'><h2>Browse By Format</h2></div>"
     - component: Column
       props:
         - label: 'colSpan'
@@ -131,7 +131,7 @@ components:
         - component: MarkdownHtmlContent
           props:
             - label: "html"
-              value: "<div><a name='location'></a><h2>Browse By Location</h2></div>"
+              value: "<div id='location'><h2>Browse By Location</h2></div>"
     - component: Column
       props:
         - label: 'colSpan'

--- a/site/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
+++ b/site/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
@@ -56,21 +56,21 @@ const IndexPage = ({ location }) => {
         <Column>
           <Card
             label='Date'
-            target='/browse#date'
+            target='/browse?scrollto=date'
             image={dateImage}
           />
         </Column>
         <Column>
           <Card
             label='Format'
-            target='/browse#format'
+            target='/browse?scrollto=format'
             image={formatImage}
           />
         </Column>
         <Column>
           <Card
             label='Campus Location'
-            target='/browse#location'
+            target='/browse?scrollto=location'
             image={campuslocationImage}
           />
         </Column>


### PR DESCRIPTION
**Reported problem:**
Going to `/browse` works fine, but going to `/browse#date` caused page 
to become unresponsive and links would not work.

**Observed problem:**
Going to `/browse#date` caused page to hang and an infinite loop was 
triggered by Okta Auth library being unable to read the cookie.

**Actual problem and solution:**
Due to the way Gatsby and Reach Router handle urls internally, there was 
a conflict with the Okta Auth library causing the Okta Auth library to 
receive incorrect information about the referring url. Since hash urls 
can be problematic in SPA and Gatsby apps and are rarely used in our 
current setup, I've opted to replace links of the format `/browse#date` 
with `/browse?scrollto=date` and add a conditional check on the `Layout` 
component to handle targeting and scrolling to the correct region of the 
page.