### PR TITLE
MARBLE-827 Fix loading to not show error pages

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/App/Pages/Portfolio/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/App/Pages/Portfolio/index.js
@@ -13,27 +13,29 @@ export const Portfolio = ({ portfolioId, location, loginReducer }) => {
 
   useEffect(() => {
     const abortController = new AbortController()
-    getData({
-      loginReducer: loginReducer,
-      contentType: 'collection',
-      id: portfolioId,
-      successFunc: (data) => {
-        const { privacy, userId } = data
-        const isOwner = ownsPage(loginReducer, userId)
-        if (privacy === 'private' && !isOwner) {
+    if (loginReducer.status === 'STATUS_NOT_LOGGED_IN' || loginReducer.status === 'STATUS_LOGGED_IN') {
+      getData({
+        loginReducer: loginReducer,
+        contentType: 'collection',
+        id: portfolioId,
+        successFunc: (data) => {
+          const { privacy, userId } = data
+          const isOwner = ownsPage(loginReducer, userId)
+          if (privacy === 'private' && !isOwner) {
+            setContent(<PortfolioUnavailable />)
+          } else {
+            setContent(<PortfolioBody
+              location={location}
+              portfolio={data}
+              isOwner={isOwner}
+            />)
+          }
+        },
+        errorFunc: () => {
           setContent(<PortfolioUnavailable />)
-        } else {
-          setContent(<PortfolioBody
-            location={location}
-            portfolio={data}
-            isOwner={isOwner}
-          />)
-        }
-      },
-      errorFunc: () => {
-        setContent(<PortfolioUnavailable />)
-      },
-    })
+        },
+      })
+    }
     return () => {
       abortController.abort()
     }

--- a/@ndlib/gatsby-theme-marble/src/components/App/Pages/User/UserBasePath/UserBasePathContent/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/App/Pages/User/UserBasePath/UserBasePathContent/index.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux'
 import { navigate } from 'gatsby'
 import {
   STATUS_NOT_LOGGED_IN,
+  STATUS_FRESH_LOAD_NOT_LOGGED_IN,
   STATUS_TRYING_AUTHENTICATION,
   STATUS_AUTHENTICATION_FAILED,
   STATUS_AUTHENTICATED_TRYING_LOGIN,
@@ -21,6 +22,7 @@ export const UserBasePathContent = ({ loginReducer }) => {
   switch (loginReducer.status) {
     case STATUS_NOT_LOGGED_IN:
       return <LoginArea loginReducer={loginReducer} />
+    case STATUS_FRESH_LOAD_NOT_LOGGED_IN:
     case STATUS_TRYING_AUTHENTICATION:
     case STATUS_AUTHENTICATED_TRYING_LOGIN:
       return <Loading />

--- a/@ndlib/gatsby-theme-marble/src/store/actions/loginActions/index.js
+++ b/@ndlib/gatsby-theme-marble/src/store/actions/loginActions/index.js
@@ -5,11 +5,13 @@ import {
 export const GET_AUTHENTICATION = 'GET_AUTHENTICATION'
 export const AUTHENTICATE_USER = 'AUTHENTICATE_USER'
 export const AUTH_ERROR = 'AUTH_ERROR'
+export const SET_NOT_LOGGED_IN = 'SET_NOT_LOGGED_IN'
 export const GET_USER = 'GET_USER'
 export const NO_USER = 'NO_USER'
 export const LOG_USER_IN = 'LOG_USER_IN'
 export const LOG_USER_OUT = 'LOG_USER_OUT'
 export const SET_AUTH_CLIENT = 'SET_AUTH_CLIENT'
+export const STATUS_FRESH_LOAD_NOT_LOGGED_IN = 'STATUS_FRESH_LOAD_NOT_LOGGED_IN'
 export const STATUS_NOT_LOGGED_IN = 'STATUS_NOT_LOGGED_IN'
 export const STATUS_TRYING_AUTHENTICATION = 'STATUS_TRYING_AUTHENTICATION'
 export const STATUS_AUTHENTICATED = 'STATUS_AUTHENTICATED'
@@ -49,14 +51,14 @@ export const getTokenAndPutInStore = (loginReducer, location) => {
         authClient.tokenManager.get('idToken')
           .then(idToken => {
             if (idToken) {
-              if (loginReducer.status === 'STATUS_NOT_LOGGED_IN') {
+              if (loginReducer.status === 'STATUS_FRESH_LOAD_NOT_LOGGED_IN') {
                 dispatch(storeAuthenticationAndGetLogin(idToken, loginReducer))
               }
               // If ID Token isn't found, try to parse it from the current URL
             } else if (location.hash) {
               authClient.token.parseFromUrl()
                 .then(idToken => {
-                // Store parsed token in Token Manager
+                  // Store parsed token in Token Manager
                   authClient.tokenManager.add('idToken', idToken)
                   dispatch(storeAuthenticationAndGetLogin(idToken, loginReducer))
                 })
@@ -64,6 +66,9 @@ export const getTokenAndPutInStore = (loginReducer, location) => {
                   console.error(error)
                   dispatch(authorizationError())
                 })
+              // No token and user has not tried to login
+            } else if (loginReducer.status === 'STATUS_FRESH_LOAD_NOT_LOGGED_IN') {
+              dispatch(setNotLoggedIn())
             }
           })
       } catch {
@@ -73,6 +78,11 @@ export const getTokenAndPutInStore = (loginReducer, location) => {
   }
 }
 
+export const setNotLoggedIn = () => {
+  return {
+    type: SET_NOT_LOGGED_IN,
+  }
+}
 export const authorizationError = () => {
   return {
     type: AUTH_ERROR,

--- a/@ndlib/gatsby-theme-marble/src/store/reducers/loginReducer/index.js
+++ b/@ndlib/gatsby-theme-marble/src/store/reducers/loginReducer/index.js
@@ -6,7 +6,9 @@ import {
   NO_USER,
   LOG_USER_IN,
   LOG_USER_OUT,
+  SET_NOT_LOGGED_IN,
   SET_AUTH_CLIENT,
+  STATUS_FRESH_LOAD_NOT_LOGGED_IN,
   STATUS_NOT_LOGGED_IN,
   STATUS_TRYING_AUTHENTICATION,
   STATUS_AUTHENTICATION_FAILED,
@@ -18,7 +20,7 @@ import {
 export const defaultState = {
   authClientSettings: null,
   userContentPath: null,
-  status: STATUS_NOT_LOGGED_IN,
+  status: STATUS_FRESH_LOAD_NOT_LOGGED_IN,
   token: null,
   user: {},
 }
@@ -26,6 +28,11 @@ export const defaultState = {
 // eslint-disable-next-line complexity
 export default (state = defaultState, action) => {
   switch (action.type) {
+    case SET_NOT_LOGGED_IN:
+      return {
+        ...state,
+        status: STATUS_NOT_LOGGED_IN,
+      }
     case GET_AUTHENTICATION:
       return {
         ...state,


### PR DESCRIPTION
* Rework reducer a little bit so we can differentiate between someone whom we have not checked to see if they are logged in and someone who is not actually logged in.
* Reduce repeated api calls when we don't have a full picture of the user on portfolio pages.