### PR TITLE
Fix tests to have both run

### DIFF
--- a/scripts/codebuild/pre_build.sh
+++ b/scripts/codebuild/pre_build.sh
@@ -4,5 +4,15 @@ reset=`tput sgr0`
 
 echo "${magenta}----- TESTS ------${reset}"
 
+
+# trap all errors as failure counts
+failures=0
+trap 'failures=$((failures+1))' ERR
+
 yarn workspace @ndlib/gatsby-theme-marble test
 yarn workspace site test
+
+if ((failures != 0)); then
+  echo "${magenta}TESTS FAILED${reset}"
+  exit 1
+fi


### PR DESCRIPTION
Basically add a bash trap to trap the following errors.
It then increments the error counter to decide if it should exit later.  