### PR TITLE
MARBLE-974 fix build for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
     - TRAVIS_RUN=1
 language: node_js
 node_js:
-  - "10"
+  - "12"
 
 cache: yarn
 before_script:

--- a/@ndlib/gatsby-theme-marble/src/components/Pages/MiradorViewer/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Pages/MiradorViewer/index.js
@@ -71,6 +71,19 @@ const MiradorViewerPage = ({ data, location }) => {
     },
 
   }
+  let body = null
+  try {
+    if (window) {
+      body = (
+        <MiradorWrapper
+          config={config}
+          plugins={plugins}
+        />
+      )
+    }
+  } catch {
+    console.warn('window does not exist in node')
+  }
   return (
     <Layout data={data} location={location}>
       <Seo
@@ -82,14 +95,7 @@ const MiradorViewerPage = ({ data, location }) => {
         noIndex
       />
       <div className='sizeWrapper' sx={sx.div}>
-        {
-          window ? (
-            <MiradorWrapper
-              config={config}
-              plugins={plugins}
-            />
-          ) : null
-        }
+        {body}
       </div>
     </Layout>
   )

--- a/scripts/gatsby-source-iiif/getSchema.js
+++ b/scripts/gatsby-source-iiif/getSchema.js
@@ -65,7 +65,13 @@ const fetchUntilGood = async (url, myArray, badArray, count = 0) => {
 // eslint-disable-next-line
 new Promise(async (resolve, reject) => {
   const rawIds = await loadManifestsFile()
-  const fetchResult = await fetchData(rawIds.manifest_ids)
+
+  let manifestIds = rawIds.manifest_ids
+  if (process.env.TRAVIS_RUN) {
+    manifestIds = rawIds.travis_manfest_ids
+  }
+
+  const fetchResult = await fetchData(manifestIds)
   if (!fetchResult) {
     reject(fetchResult)
   }

--- a/site/src/pages/sitemap.js
+++ b/site/src/pages/sitemap.js
@@ -28,7 +28,7 @@ export const AllPage = ({
         <li key={edge.node.id}>
           <Styled.a
             as={Link}
-            to={`item/${edge.node.id}`}
+            to={`item/${edge.node.slug}`}
           >
             {edge.node.title}
           </Styled.a>
@@ -81,11 +81,12 @@ AllPage.propTypes = {
 export default AllPage
 export const query = graphql`
   query {
-    allNdJson {
+    allMarbleItem {
       edges {
         node {
-          id
+          slug
           title
+          display
         }
       }
     }

--- a/site/src/pages/sitemap.js
+++ b/site/src/pages/sitemap.js
@@ -25,7 +25,7 @@ export const AllPage = ({
     })
     .map(edge => {
       return (
-        <li key={edge.node.id}>
+        <li key={edge.node.slug}>
           <Styled.a
             as={Link}
             to={`item/${edge.node.slug}`}


### PR DESCRIPTION
* Fix bad graphQL on sitemap page
* Fix call to undefined `window` on Mirador pages
* Update `getSchema.js` to use the Travis list of ids
* Update Travis to node 12, because why not?