### PR TITLE
fix missing node mappings

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.mapStandardJson.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.mapStandardJson.js
@@ -123,6 +123,14 @@ describe('mapStandardJsonMetadata', () => {
       const result = mapStandardJsonMetadata(defaultData)
       expect(result.metadata).toEqual(test)
     })
+
+    test('does not return any metadata for date if date is set but empty', () => {
+      defaultData.createdDate = ''
+      const test = [
+      ]
+      const result = mapStandardJsonMetadata(defaultData)
+      expect(result.metadata).toEqual(test)
+    })
   })
 
   describe('subjects', () => {
@@ -154,7 +162,7 @@ describe('mapStandardJsonMetadata', () => {
     })
   })
 
-  describe('publsiher', () => {
+  describe('publisher', () => {
     test('sets the publisher', () => {
       defaultData.publisher = {
         publisherName: 'Bob',
@@ -173,5 +181,97 @@ describe('mapStandardJsonMetadata', () => {
       const result = mapStandardJsonMetadata(defaultData)
       expect(result.metadata).toEqual(test)
     })
+  })
+
+  describe('providers', () => {
+    test('sets the provider for rare', () => {
+      defaultData.repository = 'rare'
+      const test = [
+        {
+          label: 'Campus Location',
+          type: 'list',
+          value:  [
+            'Rare Books and Special Collections, Hesburgh Libraries, University of Notre Dame',
+          ],
+        },
+      ]
+      const result = mapStandardJsonMetadata(defaultData)
+      expect(result.metadata).toEqual(test)
+    })
+
+    test('sets the provider for rare when it is capitalized', () => {
+      defaultData.repository = 'RARE'
+      const test = [
+        {
+          label: 'Campus Location',
+          type: 'list',
+          value:  [
+            'Rare Books and Special Collections, Hesburgh Libraries, University of Notre Dame',
+          ],
+        },
+      ]
+      const result = mapStandardJsonMetadata(defaultData)
+      expect(result.metadata).toEqual(test)
+    })
+
+    test('sets the provider for curate', () => {
+      defaultData.repository = 'curate'
+      const test = [
+        {
+          label: 'Campus Location',
+          type: 'list',
+          value:  [
+            'Rare Books and Special Collections, Hesburgh Libraries, University of Notre Dame',
+          ],
+        },
+      ]
+      const result = mapStandardJsonMetadata(defaultData)
+      expect(result.metadata).toEqual(test)
+    })
+
+    test('sets the provider for unda', () => {
+      defaultData.repository = 'unda'
+      const test = [
+        {
+          label: 'Campus Location',
+          type: 'list',
+          value:  [
+            'University of Notre Dame Archives, Hesburgh Libraries, University of Notre Dame',
+          ],
+        },
+      ]
+      const result = mapStandardJsonMetadata(defaultData)
+      expect(result.metadata).toEqual(test)
+    })
+
+    test('sets the provider for museum', () => {
+      defaultData.repository = 'museum'
+      const test = [
+        {
+          label: 'Campus Location',
+          type: 'list',
+          value:  [
+            'Snite Museum of Art',
+          ],
+        },
+      ]
+      const result = mapStandardJsonMetadata(defaultData)
+      expect(result.metadata).toEqual(test)
+    })
+  })
+
+  test('sets the provider for hesb', () => {
+    defaultData.repository = 'hesb'
+    const test = [
+      {
+        label: 'Campus Location',
+        type: 'list',
+        value:  [
+          'General Collection, Hesburgh Libraries',
+        ],
+      },
+    ]
+    const result = mapStandardJsonMetadata(defaultData)
+    expect(result.metadata).toEqual(test)
   })
 })

--- a/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/index.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/index.js
@@ -36,7 +36,7 @@ const makeMetadataArray = (standardJson) => {
 }
 
 const genericFind = (standardJson, id) => {
-  if (id in standardJson) {
+  if (id in standardJson && standardJson[id]) {
     let data = standardJson[id]
     if (!Array.isArray(data)) {
       data = [data]
@@ -71,6 +71,26 @@ const findPublisher = (standardJson) => {
     return [standardJson.publisher.publisherName]
   }
   return false
+}
+
+const findProvider = (standardJson) => {
+  if (!('repository' in standardJson)) {
+    return false
+  }
+
+  switch (standardJson.repository.toLowerCase()) {
+    case 'rare':
+    case 'curate':
+      return ['Rare Books and Special Collections, Hesburgh Libraries, University of Notre Dame']
+    case 'museum':
+      return ['Snite Museum of Art']
+    case 'unda':
+      return ['University of Notre Dame Archives, Hesburgh Libraries, University of Notre Dame']
+    case 'hesb':
+      return ['General Collection, Hesburgh Libraries']
+    default:
+      return false
+  }
 }
 
 const dataLookUp = {
@@ -113,7 +133,7 @@ const dataLookUp = {
     repository: {
       label: 'Campus Location',
       type: 'list',
-      processor: genericFind,
+      processor: findProvider,
     },
     access: {
       label: 'Conditions Governing Access',
@@ -195,7 +215,7 @@ const dataLookUp = {
     repository: {
       label: 'Campus Location',
       type: 'list',
-      processor: genericFind,
+      processor: findProvider,
     },
     access: {
       label: 'Conditions Governing Access',
@@ -272,7 +292,7 @@ const dataLookUp = {
     repository: {
       label: 'Campus Location',
       type: 'list',
-      processor: genericFind,
+      processor: findProvider,
     },
     access: {
       label: 'Access',
@@ -344,7 +364,7 @@ const dataLookUp = {
     repository: {
       label: 'Campus Location',
       type: 'list',
-      processor: genericFind,
+      processor: findProvider,
     },
     access: {
       label: 'Conditions Governing Access',

--- a/scripts/gatsby-source-iiif/indexSearch.js
+++ b/scripts/gatsby-source-iiif/indexSearch.js
@@ -49,6 +49,10 @@ const determineProvider = (manifest) => {
     return 'University Archives'
   }
 
+  if (['hesb'].includes(manifest.repository.toLowerCase())) {
+    return 'General Collection, Hesburgh Libraries'
+  }
+
   return 'Rare Books and Special Collections'
 }
 


### PR DESCRIPTION
Added mapping for the campus location. 

Fixed mappings for copyright fields that are showing up when they don't have a value.

Updated the text of general collection items in facet and in page to be correct.  