### PR TITLE
Mirador css fix

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Pages/MiradorViewer/sx.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Pages/MiradorViewer/sx.js
@@ -4,5 +4,7 @@ module.exports = {
     margin: ['-1rem -1.5rem', '-1rem -2.5rem', '-1rem -2.5rem'],
     position: 'relative',
     zIndex: '0',
+    backgroundColor: 'white',
+    transform: 'none',
   },
 }


### PR DESCRIPTION
Fix css issue where Mirador page numbering format glitches, causing black ellipsis on page