### PR TITLE
Change how path to parameter store is provided to codebuild scripts.

### DIFF
--- a/scripts/codebuild/install.sh
+++ b/scripts/codebuild/install.sh
@@ -10,9 +10,10 @@ echo "ENV_FILE: ${ENV_FILE}"
 # AWS parameter store key path(ex: /all/static-host/<stackname>/)
 # must contain search_url and search_index key/values
 # pass in 'local' for dev settings
-if [[ $# -ne 1 ]]; then
+export PARAM_CONFIG_PATH=${PARAM_CONFIG_PATH:=$1}
+if [[ -z "$PARAM_CONFIG_PATH" ]]; then
     echo "FATAL: Elasticsearch configuration required"
-    echo "scripts/codebuild/install.sh /all/static-host/<stackname>/"
+    echo "export PARAM_CONFIG_PATH=/all/static-host/<stackname>/"
     exit 2
 fi
 
@@ -33,11 +34,11 @@ yarn install || { echo "yarn install failed" ;exit 1; }
 echo "${magenta}----- CUSTOMIZATIONS -------${reset}"
 pushd scripts/gatsby-source-iiif/
 yarn install
-node setupEnv.js ${1} > ${ENV_FILE}
+node setupEnv.js ${PARAM_CONFIG_PATH} > ${ENV_FILE}
 
 source ${ENV_FILE}
 export $(cut -d= -f1 ${ENV_FILE})
-./generate.sh ${1}
+./generate.sh ${PARAM_CONFIG_PATH}
 popd
 
 echo "Copy .env to site for Gatsby"

--- a/scripts/local.sh
+++ b/scripts/local.sh
@@ -2,8 +2,9 @@
 
 yarn workspace site clean
 
-# ${1} should be parameter store path or local
-./scripts/codebuild/install.sh ${1} || { exit 1; }
+# ${1} should be parameter store path, otherwise will default to "local"
+export PARAM_CONFIG_PATH=${1:-"local"}
+./scripts/codebuild/install.sh || { exit 1; }
 ./scripts/codebuild/pre_build.sh || { exit 1; }
 ./scripts/codebuild/build.sh || { exit 1; }
 ./scripts/codebuild/post_build.sh || { exit 1; }


### PR DESCRIPTION
The current version of the codebuild scripts expects the first argument to be the path to the values in parameter store. This works well enough if you're deploying locally, or if you have a pipeline custom-built for this behavior... But for a static-host-pipeline that is supposed to be generic, it felt a little too specific of an implementation to me.

This change uses an environment variable instead, but preserves the existing functionality by using `$1` as the default in case the environment variable is not already defined. The local script also defaults to "local" so you don't have to explicitly execute `local.sh local`, which is a bit redundant. :)