### PR TITLE
MARBLE-1073 Fix Create new Portfolio Button

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/App/Pages/User/UserBody/PortfolioList/NewPortfolioButton/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/App/Pages/User/UserBody/PortfolioList/NewPortfolioButton/index.js
@@ -61,5 +61,5 @@ export const successFunc = ({ data, portfolios, addFunc, setCreating }) => {
   ps.unshift(data)
   addFunc(ps)
   setCreating(false)
-  navigate(`/myportfolio/${data.uuid}/edit`)
+  navigate(`/myportfolio/${data.uuid}`)
 }

--- a/@ndlib/gatsby-theme-marble/src/components/App/Pages/User/UserBody/PortfolioList/NewPortfolioButton/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/App/Pages/User/UserBody/PortfolioList/NewPortfolioButton/test.js
@@ -29,7 +29,7 @@ describe('NewPortfolioButton', () => {
       addFunc: addFunc,
       setCreating: jest.fn(),
     })
-    expect(navigate).toBeCalledWith('/myportfolio/asdf/edit')
+    expect(navigate).toBeCalledWith('/myportfolio/asdf')
     expect(addFunc).toBeCalledWith([{ uuid: 'asdf' }, { uuid: '1' }, { uuid: '2' }])
   })
 })

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/Card/sx.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/Card/sx.js
@@ -73,7 +73,7 @@ module.exports = {
     } : {
       borderBottom: '6px solid',
       borderColor: 'primary',
-      height: '150px',
+      height: '170px',
       overflow: 'hidden',
       padding: '.5rem',
       position: 'relative',


### PR DESCRIPTION
* Due to previous refactor adding inline editing, `/edit` page for 
portofolios no longer exist.