### PR TITLE
update to have line breaks in the description

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestDescription/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestDescription/index.js
@@ -4,7 +4,6 @@ import ReactMarkdown from 'react-markdown/with-html'
 import style from './style.module.css'
 
 const ManifestDescription = ({ marbleItem }) => {
-  console.log('Desc')
   if (marbleItem && marbleItem.description) {
     marbleItem.description = marbleItem.description.replace(/\[/g, '&#91;').replace(/\]/g, '&#93;')
     return (

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestDescription/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestDescription/index.js
@@ -1,12 +1,18 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import ReactMarkdown from 'react-markdown/with-html'
 import style from './style.module.css'
 
 const ManifestDescription = ({ marbleItem }) => {
+  console.log('Desc')
   if (marbleItem && marbleItem.description) {
+    marbleItem.description = marbleItem.description.replace(/\[/g, '&#91;').replace(/\]/g, '&#93;')
     return (
       <div className={style.descriptionBlock}>
-        <p>{marbleItem.description}</p>
+        <ReactMarkdown
+          source={marbleItem.description}
+          escapeHtml={false}
+        />
       </div>
     )
   }


### PR DESCRIPTION
I used the markdown display to catch that there are \n in the text we want to respect but that created an issue with the catalog convention [] for things that are uncertain. 

My fix is not great but these are other things i tried. 

disallowedTypes - disallowing the undocumented linkReference value just removes the text inside the [ ] 
setting a callback on linkReference.  the problem here is it ends up removing the [ ]  and because we don't know how complex props.children might be it is a little hard to put back.  also there realistically could be actual mark down here that we want. 

