### PR TITLE
MARBLE-1135 Map images onto MarbleItem

### DIFF
--- a/@ndlib/gatsby-theme-marble/gatsby-node.js
+++ b/@ndlib/gatsby-theme-marble/gatsby-node.js
@@ -24,7 +24,7 @@ exports.sourceNodes = ({ actions }) => {
     urlField: String
     type: String
   }
-  type MarbleIiifImage implements Node @dontInfer {
+  type MarbleIiifImage implements Node {
     id: String!
     marbleId: String!
     service: String
@@ -36,6 +36,7 @@ exports.sourceNodes = ({ actions }) => {
     collection: MarbleItem
     parent: MarbleItem
     sequence: Int
+    local: File @link(by: "name", from: "name")
   }
   type MarbleItem implements Node @dontInfer {
     id: String!
@@ -196,6 +197,7 @@ exports.onCreateNode = ({ node, actions, createNodeId, createContentDigest }, op
         internal: {
           type: 'MarbleIiifImage',
         },
+
       }
 
       normalizedTypeNode.internal.contentDigest = createContentDigest(normalizedTypeNode)

--- a/@ndlib/gatsby-theme-marble/gatsby-node.js
+++ b/@ndlib/gatsby-theme-marble/gatsby-node.js
@@ -38,7 +38,7 @@ exports.sourceNodes = ({ actions }) => {
     sequence: Int
     local: File @link(by: "name", from: "name")
   }
-  type MarbleItem implements Node @dontInfer {
+  type MarbleItem implements Node {
     id: String!
     marbleId: String!
     slug: String!

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
@@ -79,9 +79,12 @@ const findItem = (manifestId, allMarbleItem) => {
 }
 
 const findGatsbyImage = (item) => {
-  return typy(item, 'childrenMarbleIiifImage[0].local.childImageSharp.fluid.src').safeString ||
-  `${typy(item, 'childrenMarbleIiifImage[0].service').safeString}/full/!250,250/0/default.jpg` ||
-  noImage
+  if (typy(item, 'childrenMarbleIiifImage[0].local.childImageSharp.fluid.src').isString) {
+    return typy(item, 'childrenMarbleIiifImage[0].local.childImageSharp.fluid.src').safeString
+  }
+  return typy(item, 'childrenMarbleIiifImage[0].service').isString
+    ? `${typy(item, 'childrenMarbleIiifImage[0].service').safeString}/full/!250,250/0/default.jpg`
+    : noImage
 }
 
 ManifestCard.propTypes = {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
@@ -7,9 +7,10 @@ import Card from 'components/Shared/Card'
 import TypeLabel from './TypeLabel'
 import ManifestCardChildren from './ManifestCardChildren'
 import sx from './sx'
+import noImage from 'assets/images/noImage.svg'
 
 export const ManifestCard = (props) => {
-  const { allMarbleItem, allFile } = useStaticQuery(
+  const { allMarbleItem } = useStaticQuery(
     graphql`
     query {
       allMarbleItem {
@@ -22,22 +23,18 @@ export const ManifestCard = (props) => {
           display
           childrenMarbleIiifImage {
             service
-            name
+            local {
+              publicURL
+              childImageSharp {
+                fluid(maxHeight: 250) {
+                  ...GatsbyImageSharpFluid
+                }
+              }
+            }
           }
           metadata {
             label
             value
-          }
-        }
-      }
-      allFile(filter: {extension: {eq: "jpg"}}) {
-        nodes {
-          name
-          publicURL
-          childImageSharp {
-            fluid(maxHeight: 250) {
-              ...GatsbyImageSharpFluid
-            }
           }
         }
       }
@@ -50,7 +47,7 @@ export const ManifestCard = (props) => {
     return null
   }
 
-  const gatsbyImage = findGatsbyImage(item, allFile)
+  const gatsbyImage = findGatsbyImage(item)
   let title = ''
   if (props.highlight && props.highlight['name.folded']) {
     title = props.highlight['name.folded'][0]
@@ -62,8 +59,7 @@ export const ManifestCard = (props) => {
       <Card
         label={title}
         target={`/${item.slug}`}
-        image={typy(gatsbyImage, 'src').safeString}
-        imageService={typy(item, 'childrenMarbleIiifImage[0].service').safeString}
+        image={gatsbyImage}
         {...props}
       >
         <ManifestCardChildren
@@ -82,14 +78,10 @@ const findItem = (manifestId, allMarbleItem) => {
   })
 }
 
-const findGatsbyImage = (item, allFile) => {
-  if (!typy(item, 'childrenMarbleIiifImage[0].name').isString) {
-    return null
-  }
-  const result = allFile.nodes.find(file => {
-    return file.name.includes(typy(item, 'childrenMarbleIiifImage[0].name').safeString)
-  })
-  return typy(result, 'childImageSharp.fluid').safeObject
+const findGatsbyImage = (item) => {
+  return typy(item, 'childrenMarbleIiifImage[0].local.childImageSharp.fluid.src').safeString ||
+  `${typy(item, 'childrenMarbleIiifImage[0].service').safeString}/square/125,/0/default.jpg` ||
+  noImage
 }
 
 ManifestCard.propTypes = {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
@@ -22,7 +22,7 @@ export const ManifestCard = (props) => {
           iiifUri
           display
           childrenMarbleIiifImage {
-            service
+            thumbnail
             local {
               publicURL
               childImageSharp {
@@ -79,12 +79,7 @@ const findItem = (manifestId, allMarbleItem) => {
 }
 
 const findGatsbyImage = (item) => {
-  if (typy(item, 'childrenMarbleIiifImage[0].local.childImageSharp.fluid.src').isString) {
-    return typy(item, 'childrenMarbleIiifImage[0].local.childImageSharp.fluid.src').safeString
-  }
-  return typy(item, 'childrenMarbleIiifImage[0].service').isString
-    ? `${typy(item, 'childrenMarbleIiifImage[0].service').safeString}/full/!250,250/0/default.jpg`
-    : noImage
+  return typy(item, 'childrenMarbleIiifImage[0].local.childImageSharp.fluid.src').safeString || typy(item, 'childrenMarbleIiifImage[0].thumbnail').safeString || noImage
 }
 
 ManifestCard.propTypes = {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
@@ -79,7 +79,9 @@ const findItem = (manifestId, allMarbleItem) => {
 }
 
 const findGatsbyImage = (item) => {
-  return typy(item, 'childrenMarbleIiifImage[0].local.childImageSharp.fluid.src').safeString || typy(item, 'childrenMarbleIiifImage[0].thumbnail').safeString || noImage
+  return typy(item, 'childrenMarbleIiifImage[0].local.childImageSharp.fluid.src').safeString ||
+  typy(item, 'childrenMarbleIiifImage[0].thumbnail').safeString ||
+  noImage
 }
 
 ManifestCard.propTypes = {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
@@ -80,7 +80,7 @@ const findItem = (manifestId, allMarbleItem) => {
 
 const findGatsbyImage = (item) => {
   return typy(item, 'childrenMarbleIiifImage[0].local.childImageSharp.fluid.src').safeString ||
-  `${typy(item, 'childrenMarbleIiifImage[0].service').safeString}/square/125,/0/default.jpg` ||
+  `${typy(item, 'childrenMarbleIiifImage[0].service').safeString}/full/!250,250/0/default.jpg` ||
   noImage
 }
 

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestImageGroup/ItemAlternateViews/AlternateImage/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestImageGroup/ItemAlternateViews/AlternateImage/index.js
@@ -5,14 +5,12 @@ import PropTypes from 'prop-types'
 import ViewerLink from 'components/Shared/ManifestImageGroup/ViewerLink'
 import Image from 'components/Shared/Image'
 import AlternateOverlay from './AlternateOverlay'
-// import getImageService from 'utils/getImageService'
 import buildReferalState from 'utils/buildReferalState'
 import { findAltImage } from 'utils/findImage'
 import { jsx } from 'theme-ui'
 import sx from './sx'
 
 export const AlternateImage = ({
-  allFile,
   marbleItem,
   index,
   max,
@@ -38,7 +36,7 @@ export const AlternateImage = ({
             overlayNumber={length - max}
           />
           <Image
-            src={findAltImage(marbleItem, allFile, index)}
+            src={findAltImage(marbleItem, index)}
             alt={`Alternate View ${index}`}
             title={`Alternate View ${index}`}
           />
@@ -49,7 +47,6 @@ export const AlternateImage = ({
 }
 
 AlternateImage.propTypes = {
-  allFile: PropTypes.object,
   marbleItem: PropTypes.shape({
     childrenMarbleIiifImage: PropTypes.array,
   }).isRequired,

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestImageGroup/ItemAlternateViews/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestImageGroup/ItemAlternateViews/index.js
@@ -7,7 +7,7 @@ import AlternateImage from './AlternateImage'
 // tests if/when this number changes
 export const MAX_IMAGES = 5
 
-const ItemAlternateViews = ({ allFile, marbleItem, viewer, location }) => {
+const ItemAlternateViews = ({ marbleItem, viewer, location }) => {
   const canvases = typy(marbleItem, 'childrenMarbleIiifImage').safeArray
   if (canvases.length > 1) {
     return (
@@ -16,7 +16,6 @@ const ItemAlternateViews = ({ allFile, marbleItem, viewer, location }) => {
           canvases.slice(1, Math.min(MAX_IMAGES + 1, canvases.length)).map((canvas, index) => {
             return (
               <AlternateImage
-                allFile={allFile}
                 key={index}
                 marbleItem={marbleItem}
                 index={index + 1}
@@ -35,7 +34,7 @@ const ItemAlternateViews = ({ allFile, marbleItem, viewer, location }) => {
 }
 
 ItemAlternateViews.propTypes = {
-  allFile: PropTypes.object,
+
   marbleItem: PropTypes.object.isRequired,
   viewer: PropTypes.string,
   location: PropTypes.object.isRequired,

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestImageGroup/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestImageGroup/index.js
@@ -1,6 +1,5 @@
 /** @jsx jsx */
 import PropTypes from 'prop-types'
-import { useStaticQuery, graphql } from 'gatsby'
 import ViewerLink from './ViewerLink'
 import ExpandIcon from './ExpandIcon'
 import ItemAlternateViews from './ItemAlternateViews'
@@ -9,23 +8,6 @@ import { jsx } from 'theme-ui'
 import sx from './sx'
 
 export const ManifestImageGroup = ({ location, marbleItem, viewer }) => {
-  const { allFile } = useStaticQuery(
-    graphql`
-    query {
-      allFile(filter: {extension: {eq: "jpg"}}) {
-        nodes {
-          name
-          publicURL
-          childImageSharp {
-            fixed(width: 125, height: 125) {
-              ...GatsbyImageSharpFixed
-            }
-          }
-        }
-      }
-    }
-  `,
-  )
   if (!marbleItem) {
     return null
   }
@@ -44,7 +26,7 @@ export const ManifestImageGroup = ({ location, marbleItem, viewer }) => {
       >
         <picture sx={sx.wrapper}>
           <img
-            src={findImage(marbleItem, allFile)}
+            src={findImage(marbleItem)}
             alt={label}
             title={label}
             sx={sx.image}
@@ -53,7 +35,6 @@ export const ManifestImageGroup = ({ location, marbleItem, viewer }) => {
         </picture>
       </ViewerLink>
       <ItemAlternateViews
-        allFile={allFile}
         marbleItem={marbleItem}
         location={location}
         viewer={viewer}

--- a/@ndlib/gatsby-theme-marble/src/templates/marbleItem.js
+++ b/@ndlib/gatsby-theme-marble/src/templates/marbleItem.js
@@ -46,14 +46,18 @@ export const query = graphql`
         type
       }
       childrenMarbleIiifImage {
-        id
-        default
-        title
-        service
-        thumbnail
         sequence
-        name
-        extension
+        service
+        default
+        thumbnail
+        local {
+          publicURL
+          childImageSharp {
+            fixed(width: 125, height: 125) {
+              ...GatsbyImageSharpFixed
+            }
+          }
+        }
       }
       childrenMarbleItem {
         iiifUri

--- a/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.findImage.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.findImage.js
@@ -5,31 +5,30 @@ describe('findImage', () => {
   test('local', () => {
     const item = {
       childrenMarbleIiifImage: [
-        { name: 'image' },
+        {
+          local: {
+            publicURL: 'local.image',
+          },
+        },
       ],
     }
-    const allFile = {
-      nodes: [{
-        name: 'image',
-        publicURL: 'local.image',
-      }],
-    }
-    const result = findImage(item, allFile)
+
+    const result = findImage(item)
     expect(result).toEqual('local.image')
   })
+
   test('remote', () => {
     const item = {
       childrenMarbleIiifImage: [
         {
-          name: 'image',
           default: 'https://remote',
         },
       ],
     }
-    const allFile = { nodes: [] }
-    const result = findImage(item, allFile)
+    const result = findImage(item)
     expect(result).toEqual('https://remote')
   })
+
   test('noImage', () => {
     const item = {}
     const allFile = {}
@@ -42,39 +41,36 @@ describe('findAltImage', () => {
   test('local', () => {
     const item = {
       childrenMarbleIiifImage: [
-        { name: 'image' },
-      ],
-    }
-    const allFile = {
-      nodes: [{
-        name: 'image',
-        childImageSharp: {
-          fixed: {
-            src: 'local.image',
+        {
+          local: {
+            childImageSharp: {
+              fixed: {
+                src: 'local.image',
+              },
+            },
           },
         },
-      }],
+      ],
     }
-    const result = findAltImage(item, allFile, 0)
+    const result = findAltImage(item, 0)
     expect(result).toEqual('local.image')
   })
+
   test('remote', () => {
     const item = {
       childrenMarbleIiifImage: [
         {
-          name: 'image',
           service: 'https://remote',
         },
       ],
     }
-    const allFile = { nodes: [] }
-    const result = findAltImage(item, allFile, 0)
+    const result = findAltImage(item, 0)
     expect(result).toEqual('https://remote/square/125,/0/default.jpg')
   })
+
   test('noImage', () => {
     const item = {}
-    const allFile = {}
-    const result = findAltImage(item, allFile, 0)
+    const result = findAltImage(item, 0)
     expect(result).toEqual(noImage)
   })
 })

--- a/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.mapImageMetadata.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.mapImageMetadata.js
@@ -18,7 +18,7 @@ describe('mapImageMetadata', () => {
     const test = {
       default: 'https://image.server.com/iiif/file/full/full/0/default.jpg',
       service: 'https://image.server.com/iiif/file',
-      thumbnail: 'https://image.server.com/iiif/file/full/400,/0/default.jpg',
+      thumbnail: 'https://image.server.com/iiif/file/full/!250,250/0/default.jpg',
       sequence: 0,
       title: 'title',
       name: 'billy-bob',

--- a/@ndlib/gatsby-theme-marble/src/utils/findImage.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/findImage.js
@@ -1,24 +1,18 @@
 import typy from 'typy'
 import noImage from 'assets/images/noImage.svg'
-export const findImage = (item, allFile) => {
-  if (!typy(item, 'childrenMarbleIiifImage[0].name').isString) {
-    return noImage
-  }
-
-  const result = allFile.nodes.find(file => {
-    return file.name.includes(typy(item, 'childrenMarbleIiifImage[0].name').safeString)
-  })
-  return typy(result, 'publicURL').safeString || typy(item, 'childrenMarbleIiifImage[0].default').safeString
+export const findImage = (item) => {
+  return typy(item, 'childrenMarbleIiifImage[0].local.publicURL').safeString ||
+  typy(item, 'childrenMarbleIiifImage[0].default').safeString ||
+  noImage
 }
 export default findImage
 
-export const findAltImage = (item, allFile, index) => {
-  if (!typy(item, 'childrenMarbleIiifImage[0].name').isString) {
-    return noImage
+export const findAltImage = (item, index) => {
+  if (typy(item, `childrenMarbleIiifImage[${index}].local.childImageSharp.fixed.src`).isString) {
+    return typy(item, `childrenMarbleIiifImage[${index}].local.childImageSharp.fixed.src`).safeString
   }
 
-  const result = allFile.nodes.find(file => {
-    return file.name.includes(typy(item, `childrenMarbleIiifImage[${index}].name`).safeString)
-  })
-  return typy(result, 'childImageSharp.fixed.src').safeString || `${typy(item, `childrenMarbleIiifImage[${index}].service`).safeString}/square/125,/0/default.jpg`
+  return typy(item, `childrenMarbleIiifImage[${index}].service`).isString
+    ? `${typy(item, `childrenMarbleIiifImage[${index}].service`).safeString}/square/125,/0/default.jpg`
+    : noImage
 }

--- a/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/imageMetadata.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/imageMetadata.js
@@ -7,7 +7,7 @@ module.exports = (standardJson) => {
   return {
     default: iiifUrl.origin + path.join(iiifUrl.pathname, 'full/full/0/default.jpg'),
     service: standardJson.iiifImageUri,
-    thumbnail: iiifUrl.origin + path.join(iiifUrl.pathname, 'full/400,/0/default.jpg'),
+    thumbnail: iiifUrl.origin + path.join(iiifUrl.pathname, 'full/!250,250/0/default.jpg'),
     sequence: standardJson.sequence,
     title: standardJson.title,
     name: standardJson.collectionId && standardJson.id ? `${standardJson.collectionId}-${standardJson.id.replace(fileExtensionRegEx, '')}` : null,


### PR DESCRIPTION
* Link `marbleImage` to `marbleItem` in graphql.
* Use linked image instead of searching the hard way.
* Updated unit tests.