### PR TITLE
small steps on fixing the metadata.

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Internal/MetaDataList/MetaDataField/MetaDataMarkdownValue/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Internal/MetaDataList/MetaDataField/MetaDataMarkdownValue/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import ReactMarkdown from 'react-markdown/with-html'
 import { BaseStyles } from 'theme-ui'
 
-const MetaDataValue = ({ values, skipHtml }) => {
+const MetaDataMarkdownValue = ({ values, skipHtml }) => {
   return (
     <>
       {
@@ -25,12 +25,12 @@ const MetaDataValue = ({ values, skipHtml }) => {
   )
 }
 
-MetaDataValue.propTypes = {
+MetaDataMarkdownValue.propTypes = {
   values: PropTypes.array,
   skipHtml: PropTypes.bool,
 }
 
-MetaDataValue.defaultProps = {
+MetaDataMarkdownValue.defaultProps = {
   skipHtml: false,
 }
-export default MetaDataValue
+export default MetaDataMarkdownValue

--- a/@ndlib/gatsby-theme-marble/src/components/Internal/MetaDataList/MetaDataField/MetaDataMarkdownValue/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Internal/MetaDataList/MetaDataField/MetaDataMarkdownValue/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import ReactMarkdown from 'react-markdown/with-html'
 import { BaseStyles } from 'theme-ui'
 
-const MetaDataValue = ({ values }) => {
+const MetaDataValue = ({ values, skipHtml }) => {
   return (
     <>
       {
@@ -10,7 +11,11 @@ const MetaDataValue = ({ values }) => {
           return (
             <dd key={val}>
               <BaseStyles>
-                <p>{val}</p>
+                <ReactMarkdown
+                  source={val}
+                  escapeHtml={false}
+                  skipHtml={skipHtml}
+                />
               </BaseStyles>
             </dd>
           )
@@ -22,6 +27,10 @@ const MetaDataValue = ({ values }) => {
 
 MetaDataValue.propTypes = {
   values: PropTypes.array,
+  skipHtml: PropTypes.bool,
 }
 
+MetaDataValue.defaultProps = {
+  skipHtml: false,
+}
 export default MetaDataValue

--- a/@ndlib/gatsby-theme-marble/src/components/Internal/MetaDataList/MetaDataField/MetaDataMarkdownValue/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Internal/MetaDataList/MetaDataField/MetaDataMarkdownValue/test.js
@@ -1,16 +1,16 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import MetaDataValue from './'
+import MetaDataMarkdownValue from './'
 
-describe('MetaDataValue', () => {
+describe('MetaDataMarkdownValue', () => {
   test('values', () => {
     const values = ['value 1', 'value 2']
-    const wrapper = shallow(<MetaDataValue values={values} />)
+    const wrapper = shallow(<MetaDataMarkdownValue values={values} />)
     expect(wrapper.find('dd').length).toEqual(2)
   })
   test('null', () => {
     const values = []
-    const wrapper = shallow(<MetaDataValue values={values} />)
+    const wrapper = shallow(<MetaDataMarkdownValue values={values} />)
     expect(wrapper.find('dd').exists()).toBeFalsy()
   })
 })

--- a/@ndlib/gatsby-theme-marble/src/components/Internal/MetaDataList/MetaDataField/MetaDataMarkdownValue/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Internal/MetaDataList/MetaDataField/MetaDataMarkdownValue/test.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import MetaDataValue from './'
+
+describe('MetaDataValue', () => {
+  test('values', () => {
+    const values = ['value 1', 'value 2']
+    const wrapper = shallow(<MetaDataValue values={values} />)
+    expect(wrapper.find('dd').length).toEqual(2)
+  })
+  test('null', () => {
+    const values = []
+    const wrapper = shallow(<MetaDataValue values={values} />)
+    expect(wrapper.find('dd').exists()).toBeFalsy()
+  })
+})

--- a/@ndlib/gatsby-theme-marble/src/components/Internal/MetaDataList/MetaDataField/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Internal/MetaDataList/MetaDataField/index.js
@@ -3,18 +3,17 @@ import PropTypes from 'prop-types'
 import MetaDataLabel from './MetaDataLabel'
 import MetaDataValue from './MetaDataValue'
 import MetaDataSearchValue from './MetaDataSearchValue'
+import MetaDataMarkdownValue from './MetaDataMarkdownValue'
 
 const MetaDataField = ({ metadata, skipHtml }) => {
   const { label, urlField, type } = metadata
   let { value } = metadata
-
-  let MetadataValueComponent = MetaDataValue
-  if (type === 'searchList') {
-    MetadataValueComponent = MetaDataSearchValue
-  }
   if (!Array.isArray(value) && value) {
     value = [value]
   }
+
+  const MetadataValueComponent = getComponent(type)
+
   if (value && value.length !== 0) {
     return (
       <div>
@@ -30,6 +29,16 @@ const MetaDataField = ({ metadata, skipHtml }) => {
     )
   }
   return null
+}
+
+const getComponent = (type) => {
+  if (type === 'searchList') {
+    return MetaDataSearchValue
+  } else if (type === 'markdown') {
+    return MetaDataMarkdownValue
+  }
+
+  return MetaDataValue
 }
 
 MetaDataField.propTypes = {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchFilterBox/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchFilterBox/index.js
@@ -38,6 +38,13 @@ const customQueryBuilder = (query, options) => {
     bool : {
       should : [
         {
+          match: {
+            'identifier.idMatch': {
+              query: query,
+            },
+          },
+        },
+        {
           multi_match: {
             query: query,
             fields: [

--- a/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.punctuationStripper.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.punctuationStripper.js
@@ -1,0 +1,25 @@
+import punctuationStripper from '../mapStandardJson/punctuationStripper'
+
+describe('mapStandardJsonMetadata', () => {
+  test('it strips each of the known examples', () => {
+    [
+      ['[brackets around date]', 'brackets around date'],
+      ['brachets in [text] somewhere', 'brachets in text somewhere'],
+      ['slash / at end /', 'slash / at end'],
+      ['colon: at the end :', 'colon: at the end'],
+      ['semi-colon; at the end :', 'semi-colon: at the end'],
+      ['period. at the end.', 'period. at the end'],
+      ['comma, at the end,', 'comma, at the end'],
+    ].forEach(row => {
+      expect(punctuationStripper(row[0])).toEqual(punctuationStripper(row[1]))
+    })
+  })
+
+  test('it strips whitespace off the end', () => {
+    expect(punctuationStripper('stripped space ')).toEqual('stripped space')
+  })
+
+  test('it strips whitespace off the end of another strip', () => {
+    expect(punctuationStripper('stripped space :')).toEqual('stripped space')
+  })
+})

--- a/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.punctuationStripper.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.punctuationStripper.js
@@ -7,7 +7,7 @@ describe('mapStandardJsonMetadata', () => {
       ['brachets in [text] somewhere', 'brachets in text somewhere'],
       ['slash / at end /', 'slash / at end'],
       ['colon: at the end :', 'colon: at the end'],
-      ['semi-colon; at the end :', 'semi-colon: at the end'],
+      ['semi-colon; at the end ;', 'semi-colon; at the end'],
       ['period. at the end.', 'period. at the end'],
       ['comma, at the end,', 'comma, at the end'],
     ].forEach(row => {

--- a/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/index.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/index.js
@@ -1,12 +1,13 @@
 const path = require('path')
 const citationGenerator = require(path.join(__dirname, 'citationGenerator'))
 const makeMetadataArray = require(path.join(__dirname, 'makeMetadataArray'))
+const punctuationStripper = require(path.join(__dirname, 'punctuationStripper'))
 
 module.exports = (standardJson) => {
   const slug = `item/${standardJson.id}`
 
   return {
-    title: standardJson.title,
+    title: punctuationStripper(standardJson.title),
     slug: slug,
     description: mapFieldOrDefault(standardJson, 'description', ''),
     display: standardJson.level.toLowerCase(),

--- a/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/makeMetadataArray.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/makeMetadataArray.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const languageCodes = require(path.join(__dirname, 'languageCodes'))
+const punctuationStripper = require(path.join(__dirname, 'punctuationStripper'))
 
 module.exports = (standardJson) => {
   const currentSource = dataLookUp[standardJson.sourceSystem.toLowerCase()]
@@ -21,7 +22,7 @@ const genericFind = (standardJson, id) => {
   if (id in standardJson && standardJson[id]) {
     let data = standardJson[id]
     if (!Array.isArray(data)) {
-      data = [data]
+      data = [punctuationStripper(data)]
     }
     return data
   }
@@ -200,12 +201,12 @@ const dataLookUp = {
     },
     linkToSource: {
       label: 'Link to finding aid',
-      type: 'list',
+      type: 'markdown',
       processor: genericFind,
     },
     departmentContact: {
       label: 'Contact Us',
-      type: 'list',
+      type: 'markdown',
       processor: findContact,
     },
   },
@@ -298,12 +299,12 @@ const dataLookUp = {
     },
     linkToSource: {
       label: 'Link to library catalog',
-      type: 'list',
+      type: 'markdown',
       processor: genericFind,
     },
     departmentContact: {
       label: 'Contact Us',
-      type: 'list',
+      type: 'markdown',
       processor: findContact,
     },
   },
@@ -378,7 +379,7 @@ const dataLookUp = {
     },
     departmentContact: {
       label: 'Contact Us',
-      type: 'list',
+      type: 'markdown',
       processor: findContact,
     },
   },
@@ -465,12 +466,12 @@ const dataLookUp = {
     },
     linkToSource: {
       label: 'Link to finding aid',
-      type: 'list',
+      type: 'markdown',
       processor: genericFind,
     },
     departmentContact: {
       label: 'Contact Us',
-      type: 'list',
+      type: 'markdown',
       processor: findContact,
     },
   },

--- a/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/punctuationStripper.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/punctuationStripper.js
@@ -1,0 +1,4 @@
+module.exports = (value) => {
+  value = value.trim()
+  return value.replace(/(\[|\]|[.]$|[,]$|[/]$|[:]$|[;]$)/g, '').trim()
+}

--- a/scripts/gatsby-source-iiif/indexSearch.js
+++ b/scripts/gatsby-source-iiif/indexSearch.js
@@ -207,6 +207,13 @@ const configIndexSettings = async () => {
           stopwords:  '_english_',
         },
       },
+      char_filter: {
+        specialCharactersFilter: {
+          pattern: '[^A-Za-z0-9]',
+          type: 'pattern_replace',
+          replacement: '',
+        },
+      },
       analyzer: {
         folded_analyzer: {
           tokenizer: 'standard',
@@ -223,6 +230,17 @@ const configIndexSettings = async () => {
           filter: [
             'english_stop',
             'stemmer',
+          ],
+        },
+        no_punctuation_keyword: {
+          tokenizer: 'keyword',
+          char_filter: [
+            'specialCharactersFilter',
+          ],
+          filter: [
+            'lowercase',
+            'trim',
+            'asciifolding',
           ],
         },
       },
@@ -292,6 +310,16 @@ const configIndexMappings = async () => {
           folded: {
             type:       'text',
             analyzer:   'folded_analyzer',
+          },
+        },
+      },
+      identifier: {
+        type: 'text',
+        analyzer: 'standard',
+        fields: {
+          idMatch: {
+            type: 'text',
+            analyzer: 'no_punctuation_keyword',
           },
         },
       },


### PR DESCRIPTION
A couple things here. 

Changed the display to not use markdown on fields unless we call for it. 
Added a search and an analyzer to search for things by id.  it removes punctuation from the search so it hopefully helps fuzzy matching of id searches. 
removed the punctuation from fields that are not being sent as filter keyword searches to ES. 

More to be done with the keyword properties including probably reorganizing somethings. 