### PR TITLE
Disable image harvesting

### DIFF
--- a/scripts/codebuild/build.sh
+++ b/scripts/codebuild/build.sh
@@ -15,5 +15,5 @@ echo "BUILD SEARCH URL: ${SEARCH_URL}"
 echo "BUILD SEARCH INDEX: ${SEARCH_INDEX}"
 
 # build
-export NODE_OPTIONS="--max_old_space_size=6144"
+# export NODE_OPTIONS="--max_old_space_size=6144"
 yarn workspace site build

--- a/scripts/codebuild/install.sh
+++ b/scripts/codebuild/install.sh
@@ -4,7 +4,7 @@ reset=`tput sgr0`
 
 echo "${magenta}----- SYSTEM -------${reset}"
 export CHOKIDAR_USEPOLLING=1
-echo "DEBUG INFO:"
+echo "FILE WATCHER DEBUG INFO:"
 cat /proc/sys/fs/inotify/max_user_watches
 sysctl -w fs.inotify.max_user_watches=524288
 cat /proc/sys/fs/inotify/max_user_watches

--- a/scripts/gatsby-source-iiif/generate.sh
+++ b/scripts/gatsby-source-iiif/generate.sh
@@ -4,6 +4,6 @@ site="../../site"
 # node getManifests.js ${site}
 # node generateMD.js ${site}
 node getSchema.js ${site}
-node getImageInfo.js ${site}
-node downloadImages.js ${site}
+# node getImageInfo.js ${site}
+# node downloadImages.js ${site}
 node indexSearch.js ${site}


### PR DESCRIPTION
* We are going to do additional work next sprint to optimize the build. 
This simply disables the image harvesting steps which is suffient to 
return build times to previous levels and result in a working site with 
remote images.