### PR TITLE
MARBLE-1188 Refactor ManifestCard to remove giant graphQl query

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Internal/ReturnToSearch/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Internal/ReturnToSearch/index.js
@@ -12,11 +12,20 @@ export const ReturnToSearch = ({ location }) => {
   const { t } = useTranslation()
   const context = useThemeUI()
   const iconColor = typy(context, 'theme.colors.primary').safeStringv || '#437D8A'
-  if (typy(location, 'state.referal.type').safeString === 'search') {
+  if (typy(location, 'state.referal.type').isString) {
+    let linkText = ''
+    let target = ''
+    if (typy(location, 'state.referal.type').safeString === 'search') {
+      linkText = t('common:item.returnToSearch')
+      target = `/search${location.state.referal.query}`
+    } else if (typy(location, 'state.referal.type').safeString === 'item') {
+      linkText = location.state.referal.parentName
+      target = `${location.state.referal.backLink}`
+    }
     return (
       <BaseStyles>
         <Link
-          to={`/search${location.state.referal.query}`}
+          to={target}
           sx={sx.link}
         >
           <svg
@@ -29,7 +38,7 @@ export const ReturnToSearch = ({ location }) => {
             <path d='M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z' fill={iconColor} />
             <path d='M0 0h24v24H0z' fill='none' />
           </svg>
-          <span sx={sx.text}>{t('common:item.returnToSearch')}</span>
+          <span sx={sx.text}>{linkText}</span>
         </Link>
       </BaseStyles>
     )

--- a/@ndlib/gatsby-theme-marble/src/components/Pages/MarbleItem/CollectionLayout/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Pages/MarbleItem/CollectionLayout/index.js
@@ -8,7 +8,7 @@ import ManifestMetaData from 'components/Shared/ManifestMetaData'
 import ChildManifests from 'components/Shared/ChildManifests'
 import PartiallyDigitized from 'components/Shared/PartiallyDigitized'
 
-const CollectionLayout = ({ marbleItem }) => {
+const CollectionLayout = ({ marbleItem, location }) => {
   return (
     <>
       <MultiColumn columns='5'>
@@ -19,7 +19,10 @@ const CollectionLayout = ({ marbleItem }) => {
           <PartiallyDigitized marbleItem={marbleItem} />
         </Column>
         <Column colSpan='3'>
-          <ChildManifests marbleItem={marbleItem} />
+          <ChildManifests
+            marbleItem={marbleItem}
+            location={location}
+          />
         </Column>
       </MultiColumn>
     </>
@@ -27,6 +30,7 @@ const CollectionLayout = ({ marbleItem }) => {
 }
 
 CollectionLayout.propTypes = {
+  location: PropTypes.object.isRequired,
   marbleItem: PropTypes.object.isRequired,
 }
 export default CollectionLayout

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/CardGroup/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/CardGroup/index.js
@@ -5,6 +5,9 @@ import PropTypes from 'prop-types'
 import { BaseStyles, jsx } from 'theme-ui'
 import sx from './sx'
 const CardGroup = ({ label, children }) => {
+  if (!children) {
+    return null
+  }
   return (
     <React.Fragment>
       <BaseStyles>
@@ -33,7 +36,7 @@ const CardGroup = ({ label, children }) => {
 
 CardGroup.propTypes = {
   label: PropTypes.string,
-  children: PropTypes.array.isRequired,
+  children: PropTypes.array,
 }
 
 export default CardGroup

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ChildManifests/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ChildManifests/index.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-unused-vars
 import React from 'react'
 import PropTypes from 'prop-types'
 import typy from 'typy'

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ChildManifests/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ChildManifests/index.js
@@ -3,14 +3,13 @@ import PropTypes from 'prop-types'
 import typy from 'typy'
 import DisplayViewToggle from 'components/Internal/DisplayViewToggle'
 import ManifestCard from '../ManifestCard'
-import buildReferalState from 'utils/buildReferalState'
 
 export const ChildManifests = ({ marbleItem }) => {
   if (!marbleItem || !typy(marbleItem, 'childrenMarbleItem').isArray) {
     return null
   }
   return (
-    <React.Fragment>
+    <>
       <h2 className='accessibilityOnly'>Related Items</h2>
       <DisplayViewToggle>
         {
@@ -35,7 +34,7 @@ export const ChildManifests = ({ marbleItem }) => {
           })
         }
       </DisplayViewToggle>
-    </React.Fragment>
+    </>
   )
 }
 

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ChildManifests/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ChildManifests/index.js
@@ -3,36 +3,44 @@ import PropTypes from 'prop-types'
 import typy from 'typy'
 import DisplayViewToggle from 'components/Internal/DisplayViewToggle'
 import ManifestCard from '../ManifestCard'
+import buildReferalState from 'utils/buildReferalState'
 
 export const ChildManifests = ({ marbleItem }) => {
   if (!marbleItem || !typy(marbleItem, 'childrenMarbleItem').isArray) {
     return null
   }
   return (
-    <>
+    <React.Fragment>
       <h2 className='accessibilityOnly'>Related Items</h2>
       <DisplayViewToggle>
         {
-          typy(marbleItem, 'childrenMarbleItem').safeArray.map(manifest => {
-            if (!manifest) {
+          typy(marbleItem, 'childrenMarbleItem').safeArray.map(childItem => {
+            if (!childItem) {
               return null
             }
             return (
               <ManifestCard
-                key={manifest.iiifUri}
-                iiifManifest={manifest.iiifUri}
+                key={childItem}
+                target={childItem.slug}
+                image={typy(childItem, 'childrenMarbleIiifImage[0].thumbnail').safeString}
+                label={childItem.title}
                 showSummary
+                referal={{
+                  type: 'item',
+                  backLink: `/${marbleItem.slug}`,
+                  parentName: marbleItem.title,
+                }}
               />
             )
           })
         }
       </DisplayViewToggle>
-    </>
+    </React.Fragment>
   )
 }
 
 ChildManifests.propTypes = {
-  marbleItem: PropTypes.object.isRequired,
+  marbleItem: PropTypes.object,
 }
 
 export default ChildManifests

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/ChildField/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/ChildField/index.js
@@ -1,0 +1,26 @@
+/** @jsx jsx */
+import PropTypes from 'prop-types'
+import { jsx } from 'theme-ui'
+import typy from 'typy'
+import sx from '../../sx'
+
+export const ChildField = ({ field }) => {
+  if (field) {
+    return (
+      <p
+        sx={sx.lineStyle}
+        dangerouslySetInnerHTML={{ __html: typy(field).isArray ? field.join('<br/>') : field }}
+      />
+    )
+  }
+  return null
+}
+
+ChildField.propTypes = {
+  field: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array,
+  ]),
+}
+
+export default ChildField

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
@@ -29,8 +29,14 @@ export const ManifestCardChildren = ({ parentProps, date, creator }) => {
 }
 
 ManifestCardChildren.propTypes = {
-  date: PropTypes.string,
-  creator: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+  date: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array,
+  ]),
+  creator: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array,
+  ]),
   parentProps: PropTypes.object,
 }
 export default ManifestCardChildren

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
@@ -3,8 +3,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { jsx } from 'theme-ui'
+import typy from 'typy'
 import sx from '../sx'
 
+// eslint-disable-next-line complexity
 export const ManifestCardChildren = ({ parentProps, date, creator }) => {
   return (
     <>
@@ -12,14 +14,14 @@ export const ManifestCardChildren = ({ parentProps, date, creator }) => {
         creator ? (
           <p
             sx={sx.lineStyle}
-            dangerouslySetInnerHTML={{ __html: creator }}
+            dangerouslySetInnerHTML={{ __html: typy(creator).isArray ? creator.join('<br/>') : creator }}
           />
         ) : null
       }{
         date ? (
           <p
             sx={sx.lineStyle}
-            dangerouslySetInnerHTML={{ __html: date }}
+            dangerouslySetInnerHTML={{ __html: typy(date).isArray ? date.join('<br/>') : date }}
           />
         ) : null
       }

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types'
 import { jsx } from 'theme-ui'
 import ChildField from './ChildField'
 
-// eslint-disable-next-line complexity
 export const ManifestCardChildren = ({ parentProps, date, creator }) => {
   return (
     <>

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
@@ -1,63 +1,36 @@
 /** @jsx jsx */
+// eslint-disable-next-line no-unused-vars
 import React from 'react'
 import PropTypes from 'prop-types'
-import typy from 'typy'
 import { jsx } from 'theme-ui'
 import sx from '../sx'
 
-export const ManifestCardChildren = ({ parentProps, item }) => {
-  const dates = findMetadata(item, ['date', 'dates'])
-  const creator = findCreator(item, parentProps)
+export const ManifestCardChildren = ({ parentProps, date, creator }) => {
   return (
-    <React.Fragment>
+    <>
       {
-        parentProps.showCreator ? (
+        creator ? (
           <p
             sx={sx.lineStyle}
             dangerouslySetInnerHTML={{ __html: creator }}
           />
         ) : null
-      }
-      {
-        parentProps.showDate ? (
+      }{
+        date ? (
           <p
             sx={sx.lineStyle}
-            dangerouslySetInnerHTML={{ __html: dates }}
+            dangerouslySetInnerHTML={{ __html: date }}
           />
         ) : null
       }
-      {parentProps.showSummary ? <div>{item.description}</div> : null}
       {parentProps.children ? parentProps.children : null}
-    </React.Fragment>
+    </>
   )
 }
 
 ManifestCardChildren.propTypes = {
+  date: PropTypes.string,
+  creator: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   parentProps: PropTypes.object,
-  item: PropTypes.object,
 }
 export default ManifestCardChildren
-
-export const findMetadata = (manifest, options) => {
-  if (!manifest.metadata) {
-    return []
-  }
-
-  return manifest.metadata.reduce((metaValue, row) => {
-    const label = typy(row, 'label').safeString.toLowerCase()
-
-    if (options.includes(label)) {
-      return metaValue.concat(row.value.join('<br/>'))
-    }
-
-    return metaValue
-  }, [])
-}
-
-export const findCreator = (item, parentProps) => {
-  if (parentProps.highlight && parentProps.highlight['creator.folded']) {
-    return parentProps.highlight['creator.folded'][0]
-  } else {
-    return findMetadata(item, ['creator'])
-  }
-}

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
@@ -3,28 +3,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { jsx } from 'theme-ui'
-import typy from 'typy'
-import sx from '../sx'
+import ChildField from './ChildField'
 
 // eslint-disable-next-line complexity
 export const ManifestCardChildren = ({ parentProps, date, creator }) => {
   return (
     <>
-      {
-        creator ? (
-          <p
-            sx={sx.lineStyle}
-            dangerouslySetInnerHTML={{ __html: typy(creator).isArray ? creator.join('<br/>') : creator }}
-          />
-        ) : null
-      }{
-        date ? (
-          <p
-            sx={sx.lineStyle}
-            dangerouslySetInnerHTML={{ __html: typy(date).isArray ? date.join('<br/>') : date }}
-          />
-        ) : null
-      }
+      <ChildField field={creator} />
+      <ChildField field={date} />
       {parentProps.children ? parentProps.children : null}
     </>
   )

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/test.js
@@ -20,22 +20,17 @@ describe('ManifestCardChildren', () => {
   }
   test('children no additional', () => {
     const props = {
-      showCreator: false,
-      showDate: false,
       children: <div className='child'>children are loud</div>,
     }
-    const wrapper = mount(<ManifestCardChildren parentProps={props} item={item} />)
+    const wrapper = mount(<ManifestCardChildren parentProps={props} />)
     expect(wrapper.find('.child').text()).toEqual('children are loud')
   })
 
   test('children + additional', () => {
     const props = {
-      showCreator: true,
-      showDate: true,
-      showSummary: false,
       children: <div className='child'>A song about an alligator.</div>,
     }
-    const wrapper = mount(<ManifestCardChildren parentProps={props} item={item} />)
+    const wrapper = mount(<ManifestCardChildren parentProps={props} creator={item.metadata[0].value} date={item.metadata[1].value} />)
     expect(wrapper.find('p').at(0).html()).toContain('Johnny Horton<br>Andrew Jackson')
     expect(wrapper.find('p').at(1).text()).toEqual('1814')
     expect(wrapper.findWhere(c => {
@@ -45,12 +40,8 @@ describe('ManifestCardChildren', () => {
   })
 
   test('no children', () => {
-    const props = {
-      showCreator: true,
-      showDate: true,
-      showSummary: true,
-    }
-    const wrapper = mount(<ManifestCardChildren parentProps={props} item={item} />)
+    const props = { children: item.description }
+    const wrapper = mount(<ManifestCardChildren parentProps={props} creator={item.metadata[0].value} date={item.metadata[1].value} />)
     expect(wrapper.find('p').at(0).html()).toContain('Johnny Horton<br>Andrew Jackson')
     expect(wrapper.find('p').at(1).text()).toEqual('1814')
     expect(wrapper.findWhere(c => {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/TypeLabel/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/TypeLabel/index.js
@@ -5,7 +5,7 @@ import { jsx } from 'theme-ui'
 import sx from './sx'
 
 const TypeLabel = ({ type }) => {
-  if (type.toLowerCase() === 'collection') {
+  if (type && type.toLowerCase() === 'collection') {
     return (
       <div sx={sx.wrapper}>
         <img

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
@@ -44,7 +44,10 @@ ManifestCard.propTypes = {
     PropTypes.string,
     PropTypes.array,
   ]),
-  date: PropTypes.string,
+  date: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array,
+  ]),
   type: PropTypes.string,
 
 }

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
@@ -1,97 +1,52 @@
 /** @jsx jsx */
 import PropTypes from 'prop-types'
-import { useStaticQuery, graphql } from 'gatsby'
-import typy from 'typy'
 import { jsx } from 'theme-ui'
 import Card from 'components/Shared/Card'
 import TypeLabel from './TypeLabel'
 import ManifestCardChildren from './ManifestCardChildren'
 import sx from './sx'
-import noImage from 'assets/images/noImage.svg'
 
 export const ManifestCard = (props) => {
-  const { allMarbleItem } = useStaticQuery(
-    graphql`
-    query {
-      allMarbleItem {
-        nodes {
-          id
-          marbleId
-          slug
-          title
-          iiifUri
-          display
-          childrenMarbleIiifImage {
-            thumbnail
-            local {
-              publicURL
-              childImageSharp {
-                fluid(maxHeight: 250) {
-                  ...GatsbyImageSharpFluid
-                }
-              }
-            }
-          }
-          metadata {
-            label
-            value
-          }
-        }
-      }
-    }
-  `,
-  )
-  const item = findItem(props.iiifManifest, allMarbleItem)
-  if (!item) {
-    console.warn('Could not find manifest: ', props.iiifManifest)
-    return null
-  }
-
-  const gatsbyImage = findGatsbyImage(item)
-  let title = ''
-  if (props.highlight && props.highlight['name.folded']) {
-    title = props.highlight['name.folded'][0]
-  } else {
-    title = item.title
-  }
+  const {
+    label,
+    target,
+    image,
+    creator,
+    date,
+    type,
+  } = props
   return (
     <div sx={sx.wrapper}>
       <Card
-        label={title}
-        target={`/${item.slug}`}
-        image={gatsbyImage}
+        label={label}
+        target={target}
+        image={image}
         {...props}
       >
         <ManifestCardChildren
-          item={item}
+          date={date}
+          creator={creator}
           parentProps={props}
         />
       </Card>
-      <TypeLabel type={item.display} />
+      <TypeLabel type={type} />
     </div>
   )
 }
 
-const findItem = (manifestId, allMarbleItem) => {
-  return allMarbleItem.nodes.find(item => {
-    return item.marbleId === manifestId || item.iiifUri === manifestId
-  })
-}
-
-const findGatsbyImage = (item) => {
-  return typy(item, 'childrenMarbleIiifImage[0].local.childImageSharp.fluid.src').safeString ||
-  typy(item, 'childrenMarbleIiifImage[0].thumbnail').safeString ||
-  noImage
-}
-
 ManifestCard.propTypes = {
-  iiifManifest: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
-  imageRegion: PropTypes.string,
-  showCreator: PropTypes.bool,
-  showDate: PropTypes.bool,
-  showSummary: PropTypes.bool,
+  label: PropTypes.string,
+  target: PropTypes.string,
+  image: PropTypes.string,
+  referal: PropTypes.object,
   children: PropTypes.node,
-  highlight: PropTypes.object,
+  creator: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array,
+  ]),
+  date: PropTypes.string,
+  type: PropTypes.string,
+
 }
 ManifestCard.defaultProps = {
   showCreator: true,

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/test.js
@@ -1,43 +1,26 @@
 import React from 'react'
 import { shallow } from 'enzyme'
-import { useStaticQuery } from 'gatsby'
 import ManifestCard from './'
+import ManifestCardChildren from './ManifestCardChildren'
+import TypeLabel from './TypeLabel'
 import Card from 'components/Shared/Card'
 
 describe('ManifestCard', () => {
-  const sq = {
-    allMarbleItem: {
-      nodes: [
-        {
-          marbleId: 'someID',
-          title: 'label',
-          metadata: [
-          ],
-          slug: 'slug-1',
-        },
-      ],
-    },
-  }
-
   test('found', () => {
-    console.error = jest.fn()
-    useStaticQuery.mockImplementationOnce(() => {
-      return sq
-    })
-
-    const wrapper = shallow(<ManifestCard iiifManifest='someID' />)
+    const props = {
+      label: 'label',
+      target: '/slug-1',
+      image: 'my-image.jpg',
+      creator: ['creator'],
+      date: ['date'],
+      type: 'thing',
+    }
+    const wrapper = shallow(<ManifestCard {...props} />)
     expect(wrapper.find(Card).props().label).toEqual('label')
     expect(wrapper.find(Card).props().target).toEqual('/slug-1')
-  })
-
-  test('not found', () => {
-    console.error = jest.fn()
-    console.warn = jest.fn()
-    useStaticQuery.mockImplementationOnce(() => {
-      return sq
-    })
-
-    const wrapper = shallow(<ManifestCard iiifManifest='badID' />)
-    expect(wrapper.find(Card).exists()).toBeFalsy()
+    expect(wrapper.find(Card).props().image).toEqual('my-image.jpg')
+    expect(wrapper.find(ManifestCardChildren).props().date).toEqual(['date'])
+    expect(wrapper.find(ManifestCardChildren).props().creator).toEqual(['creator'])
+    expect(wrapper.find(TypeLabel).props().type).toEqual('thing')
   })
 })

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/index.js
@@ -1,0 +1,87 @@
+/** @jsx jsx */
+import { jsx } from 'theme-ui'
+import PropTypes from 'prop-types'
+import ManifestCard from 'components/Shared/ManifestCard'
+import typy from 'typy'
+const HitResult = ({ hit, referal }) => {
+  const {
+    name,
+    creator,
+    date,
+    url,
+    thumbnail,
+    type,
+  } = typy(hit, '["_source"]').safeObject
+  return (
+    <ManifestCard
+      key={hit}
+      label={highlightTitle(name, hit.highlight)}
+      target={url}
+      image={thumbnail}
+      referal={referal}
+      creator={highlightCreator(creator, hit.highlight)}
+      date={date}
+      type={type}
+    >
+      {
+        hit.highlight && hit.highlight['identifier.idMatch'] ? Object.values(hit.highlight['identifier.idMatch'])
+          .map(
+            (idMatch) => {
+              return higlightDisplay(idMatch)
+            }) : null
+      }
+      {
+        hit.highlight && hit.highlight['allMetadata.folded'] ? Object.values(hit.highlight['allMetadata.folded'])
+          .map(
+            (blob) => {
+              let row = ''
+              const stringSplit = '::'
+              blob.split(stringSplit).map(
+                (meta) => {
+                  row += meta.includes('<em>') ? meta : ''
+                  return row
+                },
+              )
+              return row !== '' ? (
+                higlightDisplay(row)
+              ) : null
+            },
+          ) : null
+      }
+    </ManifestCard>
+  )
+}
+
+const highlightTitle = (name, highlight) => {
+  if (highlight && highlight['name.folded']) {
+    return highlight['name.folded'][0]
+  }
+  return name
+}
+
+const highlightCreator = (creator, highlight) => {
+  if (highlight && highlight['creator.folded']) {
+    return highlight['creator.folded'][0]
+  }
+  return creator
+}
+
+const higlightDisplay = (row) => {
+  return (
+    <div
+      key={row}
+      dangerouslySetInnerHTML={{ __html: row }}
+      sx={{
+        '& > em': {
+          backgroundColor: 'highlight',
+        },
+      }}
+    />
+  )
+}
+
+HitResult.propTypes = {
+  hit: PropTypes.object,
+  referal: PropTypes.object,
+}
+export default HitResult

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/index.js
@@ -3,6 +3,7 @@ import { jsx } from 'theme-ui'
 import PropTypes from 'prop-types'
 import ManifestCard from 'components/Shared/ManifestCard'
 import typy from 'typy'
+
 const HitResult = ({ hit, referal }) => {
   const {
     name,

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/index.js
@@ -53,21 +53,21 @@ const HitResult = ({ hit, referal }) => {
   )
 }
 
-const highlightTitle = (name, highlight) => {
+export const highlightTitle = (name, highlight) => {
   if (highlight && highlight['name.folded']) {
-    return highlight['name.folded'][0]
+    return highlight['name.folded']
   }
   return name
 }
 
-const highlightCreator = (creator, highlight) => {
+export const highlightCreator = (creator, highlight) => {
   if (highlight && highlight['creator.folded']) {
-    return highlight['creator.folded'][0]
+    return highlight['creator.folded']
   }
   return creator
 }
 
-const higlightDisplay = (row) => {
+export const higlightDisplay = (row) => {
   return (
     <div
       key={row}

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/test.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import HitResult, {
+  highlightTitle,
+  highlightCreator,
+} from './'
+import ManifestCard from 'components/Shared/ManifestCard'
+
+describe('HitResult', () => {
+  describe('highlightTitle', () => {
+    test('title has highlight', () => {
+      const name = ['title 1', 'title 2']
+      const highlight = {
+        'name.folded': ['title 2'],
+      }
+      const actual = highlightTitle(name, highlight)
+      expect(actual).toEqual(highlight['name.folded'])
+    })
+    test('title does not have highlight', () => {
+      const name = ['title 1', 'title 2']
+      const highlight = {}
+      const actual = highlightTitle(name, highlight)
+      expect(actual).toEqual(name)
+    })
+  })
+  describe('highlightCreator', () => {
+    test('creator has highlight', () => {
+      const creator = ['creator 1', 'creator 2']
+      const highlight = {
+        'creator.folded': ['creator 2'],
+      }
+      const actual = highlightCreator(creator, highlight)
+      expect(actual).toEqual(highlight['creator.folded'])
+    })
+    test('creator does not have highlight', () => {
+      const creator = ['creator 1', 'creator 2']
+      const highlight = {}
+      const actual = highlightTitle(creator, highlight)
+      expect(actual).toEqual(creator)
+    })
+  })
+  test('render', () => {
+    const hit = {
+      _source: {
+        name: 'name',
+        creator: 'creator',
+        date: 'date',
+        url: 'url',
+        thumbnail: 'thumbnail',
+        type: 'type',
+      },
+    }
+    const wrapper = shallow(<HitResult hit={hit} />)
+    expect(wrapper.find(ManifestCard).props().label).toEqual('name')
+    expect(wrapper.find(ManifestCard).props().target).toEqual('url')
+    expect(wrapper.find(ManifestCard).props().image).toEqual('thumbnail')
+    expect(wrapper.find(ManifestCard).props().creator).toEqual('creator')
+    expect(wrapper.find(ManifestCard).props().date).toEqual('date')
+    expect(wrapper.find(ManifestCard).props().type).toEqual('type')
+  })
+  // test('all metadata hightlights', () => {
+  //   const hit = {}
+  //   const wrapper = shallow(<HitResult hit={hit} />)
+
+  // expect(wrapper.find(HitResult).at(0).children().html()).toEqual('<div class="css-1itje8o"><em>data</em></div>')
+  // expect(wrapper.find(ManifestCard).at(2).children().html()).toEqual('<div class="css-1itje8o"><em>line2data</em></div>')
+  // })
+})

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/index.js
@@ -1,11 +1,8 @@
-/** @jsx jsx */
-// eslint-disable-next-line no-unused-vars
 import React from 'react'
 import PropTypes from 'prop-types'
-import ManifestCard from 'components/Shared/ManifestCard'
 import DisplayViewToggle from 'components/Internal/DisplayViewToggle'
 import SearchAdditionalTools from 'components/Shared/SearchTools/SearchAdditionalTools'
-import { jsx } from 'theme-ui'
+import HitResult from './HitResult'
 
 const HitDisplay = ({ hits, defaultDisplay }) => {
   const referal = { type: 'search', query: window.location.search }
@@ -17,55 +14,16 @@ const HitDisplay = ({ hits, defaultDisplay }) => {
       {
         hits ? hits.map(
           (hit, index) => (
-            <ManifestCard
-              iiifManifest={hit._id}
+            <HitResult
+              hit={hit}
               key={index}
               referal={referal}
-              highlight={hit.highlight}
-            >
-              {
-                hit.highlight && hit.highlight['identifier.idMatch'] ? Object.values(hit.highlight['identifier.idMatch'])
-                  .map(
-                    (idMatch) => {
-                      return higlightDisplay(idMatch)
-                    }) : null
-              }
-              {
-                hit.highlight && hit.highlight['allMetadata.folded'] ? Object.values(hit.highlight['allMetadata.folded'])
-                  .map(
-                    (blob) => {
-                      let row = ''
-                      const stringSplit = '::'
-                      blob.split(stringSplit).map(
-                        (meta) => {
-                          row += meta.includes('<em>') ? meta : ''
-                          return row
-                        },
-                      )
-                      return row !== '' ? (
-                        higlightDisplay(row)
-                      ) : null
-                    },
-                  ) : null
-              }
-            </ManifestCard>
+            />
           ),
         ) : null
       }
     </DisplayViewToggle>
   )
-}
-
-const higlightDisplay = (row) => {
-  return (<div
-    key={row}
-    dangerouslySetInnerHTML={{ __html: row }}
-    sx={{
-      '& > em': {
-        backgroundColor: 'highlight',
-      },
-    }}
-  />)
 }
 
 HitDisplay.propTypes = {
@@ -79,14 +37,14 @@ HitDisplay.defaultProps = {
 export default HitDisplay
 
 export const HitList = ({ hits }) => {
-  return <HitDisplay hits={hits} defaultDisplay={'SEARCH_PAGE'} />
+  return <HitDisplay hits={hits} defaultDisplay='SEARCH_PAGE' />
 }
 HitList.propTypes = {
   hits: PropTypes.array,
 }
 
 export const HitGrid = ({ hits }) => {
-  return <HitDisplay hits={hits} defaultDisplay={'COLLECTION_PAGE'} />
+  return <HitDisplay hits={hits} defaultDisplay='COLLECTION_PAGE' />
 }
 HitGrid.propTypes = {
   hits: PropTypes.array,

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import HitDisplay, { HitList, HitGrid } from './'
-import ManifestCard from 'components/Shared/ManifestCard'
+import HitResult from './HitResult'
 import DisplayViewToggle from 'components/Internal/DisplayViewToggle'
 
 const hits = [
@@ -22,23 +22,10 @@ test('HitGrid', () => {
 test('HitDisplay', () => {
   const wrapper = shallow(<HitDisplay hits={hits} />)
   expect(wrapper.find(DisplayViewToggle).exists()).toBeTruthy()
-  expect(wrapper.find(ManifestCard).length).toEqual(3)
-})
-
-test('all metadata hightlights', () => {
-  const wrapper = shallow(<HitDisplay hits={hits} />)
-  expect(wrapper.find(DisplayViewToggle).exists()).toBeTruthy()
-  expect(wrapper.find(ManifestCard).at(0).children().html()).toEqual('<div class="css-1itje8o"><em>data</em></div>')
-  expect(wrapper.find(ManifestCard).at(2).children().html()).toEqual('<div class="css-1itje8o"><em>line2data</em></div>')
-})
-
-test('all metadata hightlights splits on :: and shows only the line with the data', () => {
-  const wrapper = shallow(<HitDisplay hits={hits} />)
-  expect(wrapper.find(DisplayViewToggle).exists()).toBeTruthy()
-  expect(wrapper.find(ManifestCard).at(2).children().html()).toEqual('<div class="css-1itje8o"><em>line2data</em></div>')
+  expect(wrapper.find(HitResult).length).toEqual(3)
 })
 
 test('has no cards if the hits are empty', () => {
   const wrapper = shallow(<HitDisplay hits={[]} />)
-  expect(wrapper.find(ManifestCard).length).toEqual(0)
+  expect(wrapper.find(HitResult).length).toEqual(0)
 })

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/index.js
@@ -11,6 +11,7 @@ import {
   HitGrid,
 } from './HitDisplay'
 import Pager from './Pager'
+import { sourceFilter, highlightFields } from './searchSettings'
 
 export const SearchResults = ({ defaultDisplay }) => {
   let displayComponent = HitGrid
@@ -21,8 +22,8 @@ export const SearchResults = ({ defaultDisplay }) => {
     <>
       <Hits
         hitsPerPage={50}
-        sourceFilter={['name']}
-        highlightFields={['allMetadata.folded', 'name.folded', 'creator.folded', 'identifier.idMatch']}
+        sourceFilter={sourceFilter}
+        highlightFields={highlightFields}
         listComponent={displayComponent}
         scrollTo='#gatsby-focus-wrapper'
       />

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/searchSettings.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/searchSettings.js
@@ -1,0 +1,18 @@
+module.exports = {
+  sourceFilter: [
+    'allMetadata',
+    'creator',
+    'date',
+    'identifier',
+    'name',
+    'thumbnail',
+    'type',
+    'url',
+  ],
+  highlightFields: [
+    'allMetadata.folded',
+    'name.folded',
+    'creator.folded',
+    'identifier.idMatch',
+  ],
+}

--- a/@ndlib/gatsby-theme-marble/src/templates/marbleItem.js
+++ b/@ndlib/gatsby-theme-marble/src/templates/marbleItem.js
@@ -46,6 +46,12 @@ export const query = graphql`
         type
       }
       childrenMarbleItem {
+        title
+        slug
+        childrenMarbleIiifImage {
+          thumbnail
+        }
+        description
         iiifUri
         marbleId
       }

--- a/@ndlib/gatsby-theme-marble/src/utils/findMetadata.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/findMetadata.js
@@ -1,0 +1,16 @@
+import typy from 'typy'
+export default (item, options) => {
+  if (!item.metadata) {
+    return []
+  }
+
+  return item.metadata.reduce((metaValue, row) => {
+    const label = typy(row, 'label').safeString.toLowerCase()
+
+    if (options.includes(label)) {
+      return metaValue.concat(row.value.join('<br/>'))
+    }
+
+    return metaValue
+  }, [])
+}

--- a/site/.env.development
+++ b/site/.env.development
@@ -1,5 +1,5 @@
-SEARCH_INDEX='marble-website'
-SEARCH_URL='https://search-testy-search-testy-u2vq42wckv4epdwlul2nthzvsi.us-east-1.es.amazonaws.com'
+SEARCH_INDEX='marble'
+SEARCH_URL='https://search-marbleb-test-sites-bdpe6z4vnpjgnxvzmjanok536y.us-east-1.es.amazonaws.com'
 GOOGLE_MAP_KEY='SETUP_A_GOOGLE_MAP_KEY'
 USER_CONTENT_PATH='https://b9mic83lu2.execute-api.us-east-1.amazonaws.com/prod/'
 AUTH_CLIENT_URL='https://okta.nd.edu'

--- a/site/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
+++ b/site/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
@@ -2,31 +2,56 @@
 // eslint-disable-next-line no-unused-vars
 import React from 'react'
 import PropTypes from 'prop-types'
+import { useStaticQuery, graphql } from 'gatsby'
 import { BaseStyles, jsx } from 'theme-ui'
+import typy from 'typy'
 import CardGroup from 'components/Shared/CardGroup'
 import BrowseBar from 'components/Shared/BrowseBar'
 import ManifestCard from 'components/Shared/ManifestCard'
 import MultiColumn from 'components/Shared/MultiColumn'
 import Column from 'components/Shared/Column'
 import { useTranslation } from 'react-i18next'
+import findMetadata from 'utils/findMetadata'
 
 const IndexPage = ({ location }) => {
   const { t } = useTranslation()
-  const recentAdditions = [
-    '005096943',
-    '1951.004.015',
-    '002097132',
-    '2008.039.002',
-    'MSNEa8006_EAD',
-    '002203292',
-    '2014.047.003',
-    'MSNCW5066_EAD',
-    '1999.031.002',
-  ]
-  const dateImage = 'https://image-iiif.library.nd.edu/iiif/2/2015.045.003%2F2015_045_003-v0002/full/1000,/0/default.jpg'
-  const formatImage = 'https://image-iiif.library.nd.edu/iiif/2/2017.025.667%2F2017_025_667-v0015/full/1000,/0/default.jpg'
-  const campuslocationImage = 'https://image-iiif.library.nd.edu/iiif/2/MSNMN5004_EAD%2FMSN-MN_5004-04.a.150/full/1000,/0/default.jpg'
-  const allImage = 'https://image-iiif.library.nd.edu/iiif/2/1976.057%2F1976_057-v0001/full/full/0/default.jpg'
+  const { allMarbleItem } = useStaticQuery(
+    graphql`
+      query {
+        allMarbleItem(filter: {marbleId: {in: [
+        "005096943",
+        "1951.004.015",
+        "002097132",
+        "2008.039.002",
+        "MSNEa8006_EAD",
+        "002203292",
+        "2014.047.003",
+        "MSNCW5066_EAD",
+        "1999.031.002"
+      ]}}) {
+          nodes {
+            title
+            marbleId
+            slug
+            display
+            childrenMarbleIiifImage {
+              thumbnail
+            }
+            metadata {
+              label
+              type
+              value
+            }
+          }
+        }
+      }
+    `,
+  )
+  const { nodes } = allMarbleItem
+  const dateImage = 'https://image-iiif.library.nd.edu/iiif/2/2015.045.003%2F2015_045_003-v0002/full/250,/0/default.jpg'
+  const formatImage = 'https://image-iiif.library.nd.edu/iiif/2/2017.025.667%2F2017_025_667-v0015/full/250,/0/default.jpg'
+  const campuslocationImage = 'https://image-iiif.library.nd.edu/iiif/2/MSNMN5004_EAD%2FMSN-MN_5004-04.a.150/full/250,/0/default.jpg'
+  const allImage = 'https://image-iiif.library.nd.edu/iiif/2/1976.057%2F1976_057-v0001/full/250,/0/default.jpg'
 
   return (
     <React.Fragment>
@@ -67,11 +92,16 @@ const IndexPage = ({ location }) => {
         label={t('common:search.recentAdditions')}
       >
         {
-          recentAdditions.map(manifest => {
+          nodes.map(item => {
             return (
               <ManifestCard
-                key={manifest}
-                iiifManifest={manifest}
+                key={item}
+                label={item.title}
+                target={item.slug}
+                image={typy(item, 'childrenMarbleIiifImage[0].thumbnail').safeString}
+                type={item.display}
+                creator={findMetadata(item, ['creator'])}
+                date={findMetadata(item, ['date', 'dates'])}
               />
             )
           })


### PR DESCRIPTION
* Refactor `ManifestCard` component to eliminate inefficient graphQl query.
* Modify uses of `ManifestCard` to reflect correct usage and pass in necessary props.
* Update unit tests