### PR TITLE
Update indexing to separate themes

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Pages/MarbleItem/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Pages/MarbleItem/index.js
@@ -5,6 +5,8 @@ import Layout from 'components/Layout'
 import Seo from 'components/Internal/Seo'
 import CollectionLayout from './CollectionLayout'
 import ItemLayout from './ItemLayout'
+import SearchBase from 'components/Shared/SearchBase'
+import { MenuFilter } from 'searchkit'
 
 const MarbleItem = ({ data, location }) => {
   const { marbleItem, allMarbleIiifImage } = data
@@ -32,6 +34,9 @@ const MarbleItem = ({ data, location }) => {
           />
         )
       }
+      <SearchBase>
+      </SearchBase> 
+
     </Layout>
   )
 }

--- a/@ndlib/gatsby-theme-marble/src/components/Pages/MarbleItem/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Pages/MarbleItem/index.js
@@ -5,8 +5,6 @@ import Layout from 'components/Layout'
 import Seo from 'components/Internal/Seo'
 import CollectionLayout from './CollectionLayout'
 import ItemLayout from './ItemLayout'
-import SearchBase from 'components/Shared/SearchBase'
-import { MenuFilter } from 'searchkit'
 
 const MarbleItem = ({ data, location }) => {
   const { marbleItem, allMarbleIiifImage } = data
@@ -34,9 +32,6 @@ const MarbleItem = ({ data, location }) => {
           />
         )
       }
-      <SearchBase>
-      </SearchBase> 
-
     </Layout>
   )
 }

--- a/scripts/gatsby-source-iiif/indexSearch.js
+++ b/scripts/gatsby-source-iiif/indexSearch.js
@@ -117,6 +117,8 @@ const getIdentifiers = (manifest) => {
 const getSearchDataFromManifest = (manifest) => {
   const dateData = realDatesFromCatalogedDates(manifest.createdDate)
   const creators = getCreators(manifest)
+  const themes = getKeywordsFromSubjects(manifest)
+
   const search = {
     id: manifest.id,
     name: manifest.title,
@@ -125,7 +127,8 @@ const getSearchDataFromManifest = (manifest) => {
     identifier: getIdentifiers(manifest),
 
     repository: determineProvider(manifest),
-    themeTag: getKeywordsFromSubjects(manifest),
+    themeTag: themes.themeTag,
+    expandedThemeTag: themes.expandedThemeTags,
     centuryTag: dateData.centuryTags,
 
     date: manifest.createdDate,
@@ -151,6 +154,7 @@ const getSearchDataFromManifest = (manifest) => {
   search['allMetadata'] += '::' + loadSubItemTitles(manifest)
   search['allMetadata'] += '::' + search.centuryTag.join('::')
   search['allMetadata'] += '::' + search.themeTag.join('::')
+  search['allMetadata'] += '::' + search.expandedThemeTag.join('::')
 
   return search
 }

--- a/scripts/gatsby-source-iiif/src/findThumbnail/test.js
+++ b/scripts/gatsby-source-iiif/src/findThumbnail/test.js
@@ -46,5 +46,5 @@ test('it emtpy if there is no image', () => {
       },
     ],
   }
-  expect(findThumbnail(manifest)).toEqual(' ')
+  expect(findThumbnail(manifest)).toEqual('')
 })

--- a/scripts/gatsby-source-iiif/src/getKeywordsFromSubjects/index.js
+++ b/scripts/gatsby-source-iiif/src/getKeywordsFromSubjects/index.js
@@ -1,8 +1,8 @@
 
 module.exports = (manifest) => {
-  let ret = {
+  const ret = {
     themeTag: [],
-    expandedThemeTag: []
+    expandedThemeTag: [],
   }
 
   if (!manifest.subjects) {

--- a/scripts/gatsby-source-iiif/src/getKeywordsFromSubjects/index.js
+++ b/scripts/gatsby-source-iiif/src/getKeywordsFromSubjects/index.js
@@ -1,23 +1,24 @@
 
 module.exports = (manifest) => {
+  let ret = {
+    themeTag: [],
+    expandedThemeTag: []
+  }
+
   if (!manifest.subjects) {
-    return []
+    return ret
   }
 
   if (typeof manifest.subjects === 'string' || manifest.subjects instanceof String) {
     manifest.subjects = JSON.parse(manifest.subjects.replace(/'/g, '"'))
   }
 
-  // uniqe an array of
-  // subjects.term that split all the -- into individual terms
-  // adding in the variant terms for that subject
-  // adding in the broader terms.term for that subject
-  // [].concat.apply([], []) flattens an array
-  return [...new Set([].concat.apply([], manifest.subjects.map(m => {
-    return splitTerms(m).concat(addVariants(m)).concat(addBroaderTerms(m))
-  })))].map((t) => {
-    return t.trim()
-  })
+  // unique array of subject.term.spit on -- and trimed for space
+  ret.themeTag = [...new Set([].concat.apply([], manifest.subjects.map(m => splitTerms(m))).map(t => t.trim()))]
+  // unique arrof the subject variants conated with the broader terms and trimed
+  ret.expandedThemeTag = [...new Set([].concat.apply([], manifest.subjects.map(m => addVariants(m).concat(addBroaderTerms(m)))).map(t => t.trim()))]
+
+  return ret
 }
 
 const splitTerms = (term) => {

--- a/scripts/gatsby-source-iiif/src/getKeywordsFromSubjects/test.js
+++ b/scripts/gatsby-source-iiif/src/getKeywordsFromSubjects/test.js
@@ -145,7 +145,7 @@ test('it makes unique values out of the list', () => {
       },
       {
         display: 'term1',
-        variants: ['term2']
+        variants: ['term2'],
       },
     ]),
   }

--- a/scripts/gatsby-source-iiif/src/getKeywordsFromSubjects/test.js
+++ b/scripts/gatsby-source-iiif/src/getKeywordsFromSubjects/test.js
@@ -6,7 +6,11 @@ test('returns the term from a subject', () => {
       display: 'term',
     }],
   }
-  expect(getKeywordsFromSubjects(manifest)).toEqual(['term'])
+  const test = {
+    themeTag: ['term'],
+    expandedThemeTag: [],
+  }
+  expect(getKeywordsFromSubjects(manifest)).toEqual(test)
 })
 
 test('returns the multiple terms from multiple subjects', () => {
@@ -16,7 +20,11 @@ test('returns the multiple terms from multiple subjects', () => {
       { display: 'term2' },
     ],
   }
-  expect(getKeywordsFromSubjects(manifest)).toEqual(['term1', 'term2'])
+  const test = {
+    themeTag: ['term1', 'term2'],
+    expandedThemeTag: [],
+  }
+  expect(getKeywordsFromSubjects(manifest)).toEqual(test)
 })
 
 test('returns the empty if there is no display', () => {
@@ -25,7 +33,11 @@ test('returns the empty if there is no display', () => {
       { term: 'term1' },
     ],
   }
-  expect(getKeywordsFromSubjects(manifest)).toEqual([])
+  const test = {
+    themeTag: [],
+    expandedThemeTag: [],
+  }
+  expect(getKeywordsFromSubjects(manifest)).toEqual(test)
 })
 
 test('works with json encoded in a string', () => {
@@ -36,12 +48,20 @@ test('works with json encoded in a string', () => {
     ]),
   }
 
-  expect(getKeywordsFromSubjects(manifest)).toEqual(['term1', 'term2'])
+  const test = {
+    themeTag: ['term1', 'term2'],
+    expandedThemeTag: [],
+  }
+  expect(getKeywordsFromSubjects(manifest)).toEqual(test)
 })
 
 test('it returns empty if there are no subjects', () => {
   const manifest = {}
-  expect(getKeywordsFromSubjects(manifest)).toEqual([])
+  const test = {
+    themeTag: [],
+    expandedThemeTag: [],
+  }
+  expect(getKeywordsFromSubjects(manifest)).toEqual(test)
 })
 
 test('it splits on the dashes', () => {
@@ -51,8 +71,12 @@ test('it splits on the dashes', () => {
       { display: 'term3' },
     ]),
   }
+  const test = {
+    themeTag: ['term1', 'term2', 'term3'],
+    expandedThemeTag: [],
+  }
 
-  expect(getKeywordsFromSubjects(manifest)).toEqual(['term1', 'term2', 'term3'])
+  expect(getKeywordsFromSubjects(manifest)).toEqual(test)
 })
 
 test('it adds in the broaderTerms', () => {
@@ -68,7 +92,11 @@ test('it adds in the broaderTerms', () => {
     ]),
   }
 
-  expect(getKeywordsFromSubjects(manifest)).toEqual(['term1', 'term2', 'term3'])
+  const test = {
+    themeTag: ['term1', 'term3'],
+    expandedThemeTag: ['term2'],
+  }
+  expect(getKeywordsFromSubjects(manifest)).toEqual(test)
 })
 
 test('it splits the broaderTerms', () => {
@@ -83,7 +111,11 @@ test('it splits the broaderTerms', () => {
     ]),
   }
 
-  expect(getKeywordsFromSubjects(manifest)).toEqual(['term1', 'term2', 'term3'])
+  const test = {
+    themeTag: ['term1'],
+    expandedThemeTag: ['term2', 'term3'],
+  }
+  expect(getKeywordsFromSubjects(manifest)).toEqual(test)
 })
 
 test('it adds in the variantTerms', () => {
@@ -97,7 +129,11 @@ test('it adds in the variantTerms', () => {
     ]),
   }
 
-  expect(getKeywordsFromSubjects(manifest)).toEqual(['term1', 'term2', 'term3'])
+  const test = {
+    themeTag: ['term1', 'term3'],
+    expandedThemeTag: ['term2'],
+  }
+  expect(getKeywordsFromSubjects(manifest)).toEqual(test)
 })
 
 test('it makes unique values out of the list', () => {
@@ -105,11 +141,18 @@ test('it makes unique values out of the list', () => {
     subjects: JSON.stringify([
       {
         display: ' term1 ',
-        variants: [' term1 '],
+        variants: [' term2 '],
       },
-      { display: 'term3' },
+      {
+        display: 'term1',
+        variants: ['term2']
+      },
     ]),
   }
+  const test = {
+    themeTag: ['term1'],
+    expandedThemeTag: ['term2'],
+  }
 
-  expect(getKeywordsFromSubjects(manifest)).toEqual(['term1', 'term3'])
+  expect(getKeywordsFromSubjects(manifest)).toEqual(test)
 })


### PR DESCRIPTION
The basic idea is we need to separate the 2 groups so that we can apply a different weights to searches found in each category. 