### PR TITLE
MARBLE-1259 Move Item Page primary image to right

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Internal/ReturnToSearch/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Internal/ReturnToSearch/index.js
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next'
 export const ReturnToSearch = ({ location }) => {
   const { t } = useTranslation()
   const context = useThemeUI()
-  const iconColor = typy(context, 'theme.colors.primary').safeStringv || '#437D8A'
+  const iconColor = typy(context, 'theme.colors.primary').safeString || typy(context, 'theme.colors.primary[1]').safeString
   if (typy(location, 'state.referal.type').isString) {
     let linkText = ''
     let target = ''

--- a/@ndlib/gatsby-theme-marble/src/components/Pages/MiradorViewer/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Pages/MiradorViewer/index.js
@@ -21,7 +21,8 @@ const MiradorViewerPage = ({ data, location }) => {
   const canvasIndex = parseInt(qs.cv, 10) || 0
   const viewerView = qs.view || 'default'
   const context = useThemeUI()
-  const themeColor = typy(context, 'theme.colors.primary').safeStringv || '#437D8A'
+  console.log(context)
+  const themeColor = typy(context, 'theme.colors.primary').safeString || typy(context, 'theme.colors.primary[1]').safeString
   const plugins = [...miradorImageToolsPlugin]
   const config = {
     id: typy(data, 'marbleItem.id').isString ? `id-${data.marbleItem.id}` : 'default-id',

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/HorizontalRule/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/HorizontalRule/index.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import typy from 'typy'
 import { useThemeUI, jsx } from 'theme-ui'
 
-const HorizontalRule = ({ color }) => {
+const HorizontalRule = ({ color, flourish }) => {
   const context = useThemeUI()
   const displayColor = color || typy(context, 'theme.colors.primary').safeString || '#000'
   const backgroundColor = typy(context, 'theme.colors.background').safeString || '#fff'
@@ -18,7 +18,8 @@ const HorizontalRule = ({ color }) => {
         marginBottom: ['2rem', '3rem', '3rem'],
         marginTop: ['2rem', '3rem', '3rem'],
         maxWidth: '80%',
-      }} />
+      }}
+      />
       <svg
         xmlns='http://www.w3.org/2000/svg'
         viewBox='0 0 24 24'
@@ -30,15 +31,20 @@ const HorizontalRule = ({ color }) => {
           width: '100%',
         }}
       >
-        <path
-          d='M0,0H24V24H0Z'
-          fill={backgroundColor}
-        />
-        <path
-          d='M12,13.26l-5,5,5,5,5-5ZM.69,12l5,5,5-5-5-5ZM12,.69l-5,5,5,5,5-5ZM18.29,7l-5,5,5,5,5-5Z'
-          fill={displayColor}
-        />
-
+        {
+          flourish ? (
+            <>
+              <path
+                d='M0,0H24V24H0Z'
+                fill={backgroundColor}
+              />
+              <path
+                d='M12,13.26l-5,5,5,5,5-5ZM.69,12l5,5,5-5-5-5ZM12,.69l-5,5,5,5,5-5ZM18.29,7l-5,5,5,5,5-5Z'
+                fill={displayColor}
+              />
+            </>
+          ) : null
+        }
       </svg>
     </React.Fragment>
   )
@@ -46,5 +52,9 @@ const HorizontalRule = ({ color }) => {
 
 HorizontalRule.propTypes = {
   color: PropTypes.string,
+  flourish: PropTypes.bool,
+}
+HorizontalRule.defaultProps = {
+  flourish: false,
 }
 export default HorizontalRule

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ For more information about Marble visit https://innovation.library.nd.edu/marble
 To build and test locally, you will need the following development tools installed:
 * [Node ≥10.16](https://github.com/nvm-sh/nvm#readme) - Installing via `nvm` is recommended for development.
   ```
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
-  nvm install 10
-  nvm alias default 10
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.0/install.sh | bash
+  nvm install 14
+  nvm alias default 14
   ```
 * yarn
   ```
@@ -35,7 +35,7 @@ To build and test locally, you will need the following development tools install
 
 ### Installing:
 ```
-yarn install
+yarn
 ```
 
 ### Run unit tests:

--- a/site/content/README.md
+++ b/site/content/README.md
@@ -2,7 +2,7 @@
 
 This is where the content of your marble-website-starter lives. The following files and directories are expected:
 
-* `manifests.json` ***(required)*** - This file contains a top level IIIF manifest that details the structure of the majority of the site including all collections and items that will have their own pages.
+* `manifests.json` ***(required)*** - This file contains a top level standard JSON files that details the content and structure of the majority of the site including all collections and items that will have their own pages.
 
 * `configuration.js` ***(required)*** - This includes many parameters that are used by `gatsby-config.js` to custom your site including the site name, menu structure, api keys, branding and more.
 
@@ -10,20 +10,6 @@ This is where the content of your marble-website-starter lives. The following fi
   * manifestLogo.png - Used in manifest.webmanifest
   * openGraphLogo.png - Used for Twitter Card and Open Graph in SEO components
   * siteLogo.png - Used as graphical site logo next to main navigation
-
-* `markdown/`  ***(required)*** - This folder contains the markdown content for static content pages on your site. No specific pages or naming contention exists, but examples include: 'About Us', 'Contact', 'FAQs', etc.
-
-  * `markdown/[index/home/etc].md` ***(required)*** - A markdown file with `slug: index` in the frontmatter is required to generate a home page. The file may have any filename.
-  * `markdown/[404].md` ***(required)*** - A markdown file with `slug: 404.html` in the frontmatter is required to generate the custom 404 page. The file may have any filename.
-
-  * `markdown/images/`  ***(recommended)*** - Images referenced in the frontmatter will be made available on the site:
-
-    ```
-    ---
-    myImage: './images/myImage.png'
-    ---
-    ```
-    Will be available in as: `data.markdownRemark.frontmatter.myImage.publicURL`
 
 **TODO**
 

--- a/site/src/@ndlib/gatsby-theme-marble/components/Pages/ExhibitsPage/index.js
+++ b/site/src/@ndlib/gatsby-theme-marble/components/Pages/ExhibitsPage/index.js
@@ -17,7 +17,7 @@ import sx from './sx'
 const ExhibitsPage = () => {
   const context = useThemeUI()
 
-  const iconColor = typy(context, 'theme.colors.primary').safeStringv || '#437D8A'
+  const iconColor = typy(context, 'theme.colors.primary').safeString || typy(context, 'theme.colors.primary[1]').safeString
 
   const exhibits = [
     {

--- a/site/src/@ndlib/gatsby-theme-marble/components/Pages/MarbleItem/ItemLayout/TombstoneMetadata/TombstoneField/index.js
+++ b/site/src/@ndlib/gatsby-theme-marble/components/Pages/MarbleItem/ItemLayout/TombstoneMetadata/TombstoneField/index.js
@@ -1,0 +1,40 @@
+/** @jsx jsx */
+// eslint-disable-next-line no-unused-vars
+import React from 'react'
+import PropTypes from 'prop-types'
+import { jsx } from 'theme-ui'
+import Link from 'components/Internal/Link'
+
+const TombstoneField = ({ field, sxStyle, searchField }) => {
+  return (
+    <div sx={sxStyle}>
+      {
+        field.map((values, i) => {
+          return values.value.map((value, j) => {
+            return searchField ? (
+              <Link
+                key={`${i}-${j}`}
+                to={`/search?${searchField}=${encodeURI(value)}`}
+              >{value}
+              </Link>
+            ) : (
+              <span key={`${i}-${j}`}>{value}</span>
+            )
+          })
+        })
+      }
+    </div>
+  )
+}
+
+TombstoneField.propTypes = {
+  field: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.arrayOf(PropTypes.string),
+    }),
+  ).isRequired,
+  sxStyle: PropTypes.object,
+  searchField: PropTypes.string,
+}
+
+export default TombstoneField

--- a/site/src/@ndlib/gatsby-theme-marble/components/Pages/MarbleItem/ItemLayout/TombstoneMetadata/index.js
+++ b/site/src/@ndlib/gatsby-theme-marble/components/Pages/MarbleItem/ItemLayout/TombstoneMetadata/index.js
@@ -1,0 +1,73 @@
+/** @jsx jsx */
+import { jsx, BaseStyles } from 'theme-ui'
+import PropTypes from 'prop-types'
+import typy from 'typy'
+import TombstoneField from './TombstoneField'
+import ManifestDescription from 'components/Shared/ManifestDescription'
+
+const TombstoneMetadata = ({ marbleItem }) => {
+  const creators = marbleItem.metadata.filter(m => {
+    return m.label === 'Creator'
+  })
+  const dates = marbleItem.metadata.filter(m => {
+    return m.label === 'Date'
+  })
+  const campusLocations = marbleItem.metadata.filter(m => {
+    return m.label === 'Campus Location'
+  })
+  const sx = {
+    wrapper: {
+      '& > div': {
+        margin: '0 0 1rem',
+      },
+    },
+    creators: {
+      fontSize: '1.5rem',
+      fontStyle: 'italic',
+      marginBottom: '1rem',
+      '& a': {
+        display: 'block',
+        textDecoration: 'none',
+      },
+    },
+    dates: {
+      fontSize: '1.25rem',
+      marginBottom: '1rem',
+    },
+    campusLocations: {
+      marginBottom: '1rem',
+      '& a': {
+        display: 'block',
+        textDecoration: 'none',
+      },
+    },
+  }
+  const hasCreator = typy(creators, '[0].value').safeArray.length > 0
+  return (
+    <BaseStyles>
+      <div sx={sx.wrapper}>
+        <TombstoneField
+          field={hasCreator ? creators : [{ value: ['Unknown creator'] }]}
+          searchField={hasCreator ? 'creator[0]' : null}
+          sxStyle={sx.creators}
+        />
+        <TombstoneField
+          field={dates}
+          sxStyle={sx.dates}
+        />
+        <TombstoneField
+          field={campusLocations}
+          searchField='campuslocation[0]'
+          sxStyle={sx.campusLocations}
+        />
+        <ManifestDescription marbleItem={marbleItem} />
+      </div>
+    </BaseStyles>
+  )
+}
+
+TombstoneMetadata.propTypes = {
+  marbleItem: PropTypes.object.isRequired,
+}
+
+export default TombstoneMetadata

--- a/site/src/@ndlib/gatsby-theme-marble/components/Pages/MarbleItem/ItemLayout/index.js
+++ b/site/src/@ndlib/gatsby-theme-marble/components/Pages/MarbleItem/ItemLayout/index.js
@@ -1,0 +1,70 @@
+/** @jsx jsx */
+// eslint-disable-next-line no-unused-vars
+import React from 'react'
+import PropTypes from 'prop-types'
+import { jsx, useThemeUI } from 'theme-ui'
+import typy from 'typy'
+import MultiColumn from 'components/Shared/MultiColumn'
+import Column from 'components/Shared/Column'
+import ActionButtonGroup from 'components/Shared/ActionButtonGroup'
+import ManifestImageGroup from 'components/Shared/ManifestImageGroup'
+import ManifestMetaData from 'components/Shared/ManifestMetaData'
+import PartiallyDigitized from 'components/Shared/PartiallyDigitized'
+import HorizontalRule from 'components/Shared/HorizontalRule'
+import TombstoneMetadata from './TombstoneMetadata'
+
+const ItemLayout = ({ location, marbleItem, allMarbleFile }) => {
+  const context = useThemeUI()
+  const primary = typy(context, 'theme.colors.primary').safeString || '#437D8A'
+  const accessFields = ['Accession Number', 'Campus Location', 'Access']
+  const mainMetaData = {
+    metadata: marbleItem.metadata.filter(item => {
+      return !(accessFields.includes(item.label) || item.label === 'Contact Us')
+    }),
+  }
+  const accessMetadata = {
+    metadata: marbleItem.metadata.filter(item => {
+      return accessFields.includes(item.label)
+    }),
+  }
+  const contactUsMetadata = {
+    metadata: marbleItem.metadata.filter(item => {
+      return item.label === 'Contact Us'
+    }),
+  }
+  return (
+    <>
+      <MultiColumn>
+        <Column>
+          <TombstoneMetadata marbleItem={marbleItem} />
+        </Column>
+        <Column>
+          <ActionButtonGroup marbleItem={marbleItem} />
+          <ManifestImageGroup
+            location={location}
+            marbleItem={marbleItem}
+            allMarbleFile={allMarbleFile}
+          />
+        </Column>
+      </MultiColumn>
+      <HorizontalRule color={primary} />
+      <MultiColumn columns='5'>
+        <Column colSpan='3'>
+          <ManifestMetaData marbleItem={mainMetaData} />
+          <PartiallyDigitized marbleItem={marbleItem} />
+        </Column>
+        <Column colSpan='2'>
+          <ManifestMetaData marbleItem={accessMetadata} />
+        </Column>
+      </MultiColumn>
+      <ManifestMetaData marbleItem={contactUsMetadata} />
+    </>
+  )
+}
+
+ItemLayout.propTypes = {
+  allMarbleFile: PropTypes.object,
+  marbleItem: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
+}
+export default ItemLayout


### PR DESCRIPTION
* This actually starts to address MARBLE-1259, MARBLE-1260, MARBLE-1261 and 
MARBLE-1262.
* Styling changes still need to happen for 1260 and 1261, but this gets 
the data in generally the right place.
* The majority of code changes are happening in the `/site` folder so we 
can retain a simpler Item layout page for 'site builder'
* This also fixes a couple of places where I found a typo trying to get the primary color.