### PR TITLE
Remove nextgen from inlined images

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Pages/MiradorViewer/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Pages/MiradorViewer/index.js
@@ -21,7 +21,6 @@ const MiradorViewerPage = ({ data, location }) => {
   const canvasIndex = parseInt(qs.cv, 10) || 0
   const viewerView = qs.view || 'default'
   const context = useThemeUI()
-  console.log(context)
   const themeColor = typy(context, 'theme.colors.primary').safeString || typy(context, 'theme.colors.primary[1]').safeString
   const plugins = [...miradorImageToolsPlugin]
   const config = {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/BrowseBar/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/BrowseBar/index.js
@@ -8,15 +8,10 @@ const BrowseBar = ({
   label,
   target,
   image,
-  imageNext,
 }) => {
   return (
     <Link to={target} sx={sx.browseSection}>
       <picture sx={sx.browseImage}>
-        <source
-          srcSet={imageNext}
-          type='image/webp'
-        />
         <img
           alt={label}
           src={image}
@@ -33,7 +28,6 @@ BrowseBar.propTypes = {
   target: PropTypes.string,
   label: PropTypes.string.isRequired,
   image: PropTypes.string,
-  imageNext: PropTypes.string,
 }
 
 export default BrowseBar

--- a/site/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
+++ b/site/src/@ndlib/gatsby-theme-marble/components/Pages/IndexPage/index.js
@@ -16,10 +16,6 @@ import dateImage from 'assets/images/date.jpg'
 import formatImage from 'assets/images/format.jpg'
 import campuslocationImage from 'assets/images/campus_location.jpg'
 import allImage from 'assets/images/all_items.jpg'
-import dateImageNext from 'assets/images/date.webp'
-import formatImageNext from 'assets/images/format.webp'
-import campuslocationImageNext from 'assets/images/campus_location.webp'
-import allImageNext from 'assets/images/all_items.webp'
 
 const IndexPage = ({ location }) => {
   const { t } = useTranslation()
@@ -71,7 +67,6 @@ const IndexPage = ({ location }) => {
             label='Date'
             target='/browse?scrollto=date'
             image={dateImage}
-            imageNext={dateImageNext}
           />
         </Column>
         <Column>
@@ -79,7 +74,6 @@ const IndexPage = ({ location }) => {
             label='Format'
             target='/browse?scrollto=format'
             image={formatImage}
-            imageNext={formatImageNext}
           />
         </Column>
         <Column>
@@ -87,7 +81,6 @@ const IndexPage = ({ location }) => {
             label='Campus Location'
             target='/browse?scrollto=location'
             image={campuslocationImage}
-            imageNext={campuslocationImageNext}
           />
         </Column>
         <Column>
@@ -95,7 +88,6 @@ const IndexPage = ({ location }) => {
             label='All Items'
             target='/search?q='
             image={allImage}
-            imageNext={allImageNext}
           />
         </Column>
       </MultiColumn>


### PR DESCRIPTION
These images are small enough that they get inlined with webpack. Having a progressively enhanced next gen format actually bloats the javascript.