### PR TITLE
MARBLE-1300 Sibling Item Display

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SiblingItems/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SiblingItems/index.js
@@ -1,4 +1,6 @@
 /** @jsx jsx */
+// eslint-disable-next-line no-unused-vars
+import React from 'react'
 import PropTypes from 'prop-types'
 import Link from 'components/Internal/Link'
 import { jsx, BaseStyles } from 'theme-ui'
@@ -15,12 +17,17 @@ const SiblingItems = ({ marbleItem, numberBeforeAndAfter }) => {
     const nearSiblings = getArrayNeighbors(siblings, thisItemIndex, numberBeforeAndAfter)
 
     return (
-      <BaseStyles>
-        <h2>Also from&nbsp;
-          <Link to={typy(marbleItem, 'marbleParent.slug').safeString} sx={{ textDecoration: 'none' }}>
-            <i>{typy(marbleItem, 'marbleParent.title').safeString}</i>
-          </Link>
-        </h2>
+      <>
+        <BaseStyles>
+          <h2>Also from&nbsp;
+            <Link
+              to={typy(marbleItem, 'marbleParent.slug').safeString}
+              sx={{ textDecoration: 'none' }}
+            >
+              <i>{typy(marbleItem, 'marbleParent.title').safeString}</i>
+            </Link>
+          </h2>
+        </BaseStyles>
         <DisplayViewToggle>
           {
             nearSiblings.map(sibling => {
@@ -36,7 +43,7 @@ const SiblingItems = ({ marbleItem, numberBeforeAndAfter }) => {
             })
           }
         </DisplayViewToggle>
-      </BaseStyles>
+      </>
     )
   }
   return null

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SiblingItems/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SiblingItems/index.js
@@ -5,13 +5,15 @@ import { jsx, BaseStyles } from 'theme-ui'
 import typy from 'typy'
 import DisplayViewToggle from 'components/Internal/DisplayViewToggle'
 import ManifestCard from 'components/Shared/ManifestCard'
+import getArrayNeighbors from 'utils/getArrayNeighbors'
 
-const SiblingItems = ({ marbleItem }) => {
+const SiblingItems = ({ marbleItem, numberBeforeAndAfter }) => {
   const siblings = typy(marbleItem, 'marbleParent.childrenMarbleItem').safeArray
+
   if (siblings.length > 1) {
     const thisItemIndex = siblings.findIndex(item => item.slug === marbleItem.slug)
+    const nearSiblings = getArrayNeighbors(siblings, thisItemIndex, numberBeforeAndAfter)
 
-    const nearSiblings = getNeighbors(siblings, thisItemIndex, 3)
     return (
       <BaseStyles>
         <h2>Also from&nbsp;
@@ -42,24 +44,10 @@ const SiblingItems = ({ marbleItem }) => {
 
 SiblingItems.propTypes = {
   marbleItem: PropTypes.object,
+  numberBeforeAndAfter: PropTypes.number,
 }
 
+SiblingItems.defaultProps = {
+  numberBeforeAndAfter: 3,
+}
 export default SiblingItems
-
-// eslint-disable-next-line complexity
-const getNeighbors = (arr, index, numberDirection) => {
-  const length = arr.length
-  if (length <= (2 * numberDirection) + 1) {
-    return arr.splice(index, 1)
-  }
-  const tempArr = []
-  for (let i = numberDirection; i > 0; i--) {
-    const tIndex = index - i >= 0 ? index - i : index - i + length
-    tempArr.push(arr[tIndex])
-  }
-  for (let i = 1; i < 1 + numberDirection; i++) {
-    const tIndex = i + index >= length ? i + index - length : i + index
-    tempArr.push(arr[tIndex])
-  }
-  return tempArr
-}

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SiblingItems/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SiblingItems/index.js
@@ -1,0 +1,65 @@
+/** @jsx jsx */
+import PropTypes from 'prop-types'
+import Link from 'components/Internal/Link'
+import { jsx, BaseStyles } from 'theme-ui'
+import typy from 'typy'
+import DisplayViewToggle from 'components/Internal/DisplayViewToggle'
+import ManifestCard from 'components/Shared/ManifestCard'
+
+const SiblingItems = ({ marbleItem }) => {
+  const siblings = typy(marbleItem, 'marbleParent.childrenMarbleItem').safeArray
+  if (siblings.length > 1) {
+    const thisItemIndex = siblings.findIndex(item => item.slug === marbleItem.slug)
+
+    const nearSiblings = getNeighbors(siblings, thisItemIndex, 3)
+    return (
+      <BaseStyles>
+        <h2>Also from&nbsp;
+          <Link to={typy(marbleItem, 'marbleParent.slug').safeString} sx={{ textDecoration: 'none' }}>
+            <i>{typy(marbleItem, 'marbleParent.title').safeString}</i>
+          </Link>
+        </h2>
+        <DisplayViewToggle>
+          {
+            nearSiblings.map(sibling => {
+              return (
+                <ManifestCard
+                  key={sibling.slug}
+                  target={sibling.slug}
+                  image={typy(sibling, 'childrenMarbleFile[0].iiif.thumbnail').safeString}
+                  label={sibling.title}
+                  showSummary
+                />
+              )
+            })
+          }
+        </DisplayViewToggle>
+      </BaseStyles>
+    )
+  }
+  return null
+}
+
+SiblingItems.propTypes = {
+  marbleItem: PropTypes.object,
+}
+
+export default SiblingItems
+
+// eslint-disable-next-line complexity
+const getNeighbors = (arr, index, numberDirection) => {
+  const length = arr.length
+  if (length <= (2 * numberDirection) + 1) {
+    return arr.splice(index, 1)
+  }
+  const tempArr = []
+  for (let i = numberDirection; i > 0; i--) {
+    const tIndex = index - i >= 0 ? index - i : index - i + length
+    tempArr.push(arr[tIndex])
+  }
+  for (let i = 1; i < 1 + numberDirection; i++) {
+    const tIndex = i + index >= length ? i + index - length : i + index
+    tempArr.push(arr[tIndex])
+  }
+  return tempArr
+}

--- a/@ndlib/gatsby-theme-marble/src/templates/marbleItem.js
+++ b/@ndlib/gatsby-theme-marble/src/templates/marbleItem.js
@@ -48,12 +48,20 @@ export const query = graphql`
       marbleParent {
         title
         slug
+        childrenMarbleItem {
+          title
+          slug
+          childrenMarbleFile {
+            iiif {
+              thumbnail
+            }
+          }
+        }
       }
       childrenMarbleItem {
         title
         slug
         childrenMarbleFile {
-
           file
           fileType
           iiif {

--- a/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.getArrayNeighbors.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/__tests__/test.getArrayNeighbors.js
@@ -1,0 +1,22 @@
+import getArrayNeighbors from '../getArrayNeighbors'
+
+describe('getArrayNeighbors', () => {
+  const shortArr = [0, 1, 2]
+  const arr = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+  test('array length shorter than requested items', () => {
+    const result = getArrayNeighbors(shortArr, 1, 3)
+    expect(result).toEqual([0, 2])
+  })
+  test('index in the middle', () => {
+    const result = getArrayNeighbors(arr, 4, 3)
+    expect(result).toEqual([1, 2, 3, 5, 6, 7])
+  })
+  test('index at beginning', () => {
+    const result = getArrayNeighbors(arr, 0, 3)
+    expect(result).toEqual([6, 7, 8, 1, 2, 3])
+  })
+  test('index at end', () => {
+    const result = getArrayNeighbors(arr, 8, 3)
+    expect(result).toEqual([5, 6, 7, 0, 1, 2])
+  })
+})

--- a/@ndlib/gatsby-theme-marble/src/utils/getArrayNeighbors.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/getArrayNeighbors.js
@@ -1,0 +1,26 @@
+/*
+  Takes an array, the current index, and number of siblings to the left and to the right and returns an array of those siblings. The function will wrap the array at the ends, so for example the last item in the array will return a new array with the x items before it and the first x items at the beginning of the original array.
+*/
+// eslint-disable-next-line complexity
+const getArrayNeighbors = (arr, index, numberBeforeAndAfter) => {
+  const length = arr.length
+  // If array is shorter than requested number of siblings, return original array minus the item at the current index
+  if (length <= (2 * numberBeforeAndAfter) + 1) {
+    return arr.filter((item, i) => {
+      return i !== index
+    })
+  }
+  const tempArr = []
+  // Get the siblings to the left
+  for (let i = numberBeforeAndAfter; i > 0; i--) {
+    const tIndex = index - i >= 0 ? index - i : index - i + length
+    tempArr.push(arr[tIndex])
+  }
+  // Get the sibling to the right
+  for (let i = 1; i < 1 + numberBeforeAndAfter; i++) {
+    const tIndex = i + index >= length ? i + index - length : i + index
+    tempArr.push(arr[tIndex])
+  }
+  return tempArr
+}
+export default getArrayNeighbors

--- a/site/src/@ndlib/gatsby-theme-marble/components/Pages/MarbleItem/ItemLayout/index.js
+++ b/site/src/@ndlib/gatsby-theme-marble/components/Pages/MarbleItem/ItemLayout/index.js
@@ -65,7 +65,10 @@ const ItemLayout = ({ location, marbleItem, allMarbleFile }) => {
         <ManifestMetaData marbleItem={contactUsMetadata} />
       </div>
       <HorizontalRule color={primary} />
-      <SiblingItems marbleItem={marbleItem} />
+      <SiblingItems
+        marbleItem={marbleItem}
+        numberBeforeAndAfter={3}
+      />
     </>
   )
 }

--- a/site/src/@ndlib/gatsby-theme-marble/components/Pages/MarbleItem/ItemLayout/index.js
+++ b/site/src/@ndlib/gatsby-theme-marble/components/Pages/MarbleItem/ItemLayout/index.js
@@ -11,6 +11,7 @@ import ManifestImageGroup from 'components/Shared/ManifestImageGroup'
 import ManifestMetaData from 'components/Shared/ManifestMetaData'
 import HorizontalRule from 'components/Shared/HorizontalRule'
 import TombstoneMetadata from './TombstoneMetadata'
+import SiblingItems from 'components/Shared/SiblingItems'
 import sx from './sx'
 
 const ItemLayout = ({ location, marbleItem, allMarbleFile }) => {
@@ -63,6 +64,8 @@ const ItemLayout = ({ location, marbleItem, allMarbleFile }) => {
       <div sx={sx.contactMetadata}>
         <ManifestMetaData marbleItem={contactUsMetadata} />
       </div>
+      <HorizontalRule color={primary} />
+      <SiblingItems marbleItem={marbleItem} />
     </>
   )
 }


### PR DESCRIPTION
New component to show some of the sibling items for items that belong in a collection.

* Return the 3 items before and 3 items after the current item from the parent collection.
* Wraps around the ends of the array 
* Returns whole array of siblings minus the current item if more items are requested than are in the original array
* Component will not render if there are no siblings (includes items that do not have parent and items that are in collections of a single item) 

![Screen Shot 2020-11-24 at 11 59 54 AM](https://user-images.githubusercontent.com/416559/100126959-9b21ae00-2e4c-11eb-8558-ef3cba86bc8b.png)
