### PR TITLE
MARBLE-1283 Fix font size issue with "medium" browe bar

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/BrowseBar/sx.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/BrowseBar/sx.js
@@ -22,7 +22,7 @@ module.exports = {
 
   },
   label: {
-    fontSize: ['32px', '18px', '18px'],
+    fontSize: ['1.8em', '.7em', '1em'],
     transform: 'translate(0%, -50%)',
     position: 'relative',
     top: '50%',


### PR DESCRIPTION
<img width="804" alt="Screen Shot 2020-11-30 at 1 24 51 PM" src="https://user-images.githubusercontent.com/38439231/100648988-c2c2bb80-330f-11eb-8b27-56ae1406855f.png">
