### PR TITLE
More small changes to search.

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
@@ -5,11 +5,12 @@ import PropTypes from 'prop-types'
 import { jsx } from 'theme-ui'
 import ChildField from './ChildField'
 
-export const ManifestCardChildren = ({ parentProps, date, creator }) => {
+export const ManifestCardChildren = ({ parentProps, date, creator, collectionName }) => {
   return (
     <>
       <ChildField field={creator} />
       <ChildField field={date} />
+      <ChildField field={collectionName} />
       {parentProps.children ? parentProps.children : null}
     </>
   )

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
@@ -6,11 +6,12 @@ import { jsx } from 'theme-ui'
 import ChildField from './ChildField'
 
 export const ManifestCardChildren = ({ parentProps, date, creator, collectionName }) => {
+  const collectionDisplay = 'Part of: ' + collectionName
   return (
     <>
       <ChildField field={creator} />
       <ChildField field={date} />
-      <ChildField field={collectionName ? <a>Part of: {collectionName}</a> : ''} />
+      <ChildField field={collectionName ? collectionDisplay : ''} />
       {parentProps.children ? parentProps.children : null}
     </>
   )

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/ManifestCardChildren/index.js
@@ -10,7 +10,7 @@ export const ManifestCardChildren = ({ parentProps, date, creator, collectionNam
     <>
       <ChildField field={creator} />
       <ChildField field={date} />
-      <ChildField field={collectionName} />
+      <ChildField field={collectionName ? <a>Part of: {collectionName}</a> : ''} />
       {parentProps.children ? parentProps.children : null}
     </>
   )

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestCard/index.js
@@ -11,6 +11,7 @@ export const ManifestCard = (props) => {
     target,
     image,
     creator,
+    collectionName,
     date,
     type,
   } = props
@@ -26,6 +27,7 @@ export const ManifestCard = (props) => {
         <ManifestCardChildren
           date={date}
           creator={creator}
+          collectionName={collectionName}
           parentProps={props}
         />
       </Card>

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/index.js
@@ -9,6 +9,7 @@ const HitResult = ({ hit, referal }) => {
     name,
     creator,
     date,
+    collection,
     url,
     thumbnail,
     type,
@@ -21,6 +22,7 @@ const HitResult = ({ hit, referal }) => {
       image={thumbnail}
       referal={referal}
       creator={highlightCreator(creator, hit.highlight)}
+      collectionName={highlightCollection(collection, hit.highlight)}
       date={date}
       type={type}
     >
@@ -65,6 +67,13 @@ export const highlightCreator = (creator, highlight) => {
     return highlight['creator.folded']
   }
   return creator
+}
+
+export const highlightCollection = (collection, highlight) => {
+  if (highlight && highlight['collection.folded']) {
+    return highlight['collection.folded']
+  }
+  return collection
 }
 
 export const higlightDisplay = (row) => {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/searchSettings.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/searchSettings.js
@@ -4,6 +4,7 @@ module.exports = {
     'creator',
     'date',
     'identifier',
+    'collection',
     'name',
     'thumbnail',
     'type',
@@ -13,6 +14,7 @@ module.exports = {
     'allMetadata.folded',
     'name.folded',
     'creator.folded',
+    'collection.folded',
     'identifier.idMatch',
   ],
 }

--- a/scripts/gatsby-source-iiif/indexSearch.js
+++ b/scripts/gatsby-source-iiif/indexSearch.js
@@ -93,15 +93,15 @@ const loadManifestData = () => {
 
 const loadSubItemTitles = (manifest) => {
   if (!manifest.items) {
-    return ''
+    return []
   }
 
   return manifest.items.reduce((titles, item) => {
     if (item.title && item.level !== 'file') {
-      return titles + '::' + item.title
+      titles.push(item.title)
     }
     return titles
-  }, '')
+  }, [])
 }
 
 const allMetadataKeys = [
@@ -151,16 +151,16 @@ const getSearchDataFromManifest = (manifest, collection) => {
     search['formatTag'] = [manifest.workType]
   }
 
-  search['allMetadata'] = ''
+  search['allMetadata'] = []
   allMetadataKeys.forEach((key) => {
     if (manifest[key]) {
-      search['allMetadata'] += '::' + manifest[key]
+      search['allMetadata'].push(manifest[key])
     }
   })
-  search['allMetadata'] += '::' + loadSubItemTitles(manifest)
-  search['allMetadata'] += '::' + search.centuryTag.join('::')
-  search['allMetadata'] += '::' + search.themeTag.join('::')
-  search['allMetadata'] += '::' + search.expandedThemeTag.join('::')
+  search['allMetadata'] = search['allMetadata'].concat(loadSubItemTitles(manifest))
+  search['allMetadata'] = search['allMetadata'].concat(search.centuryTag)
+  search['allMetadata'] = search['allMetadata'].concat(search.themeTag)
+  search['allMetadata'] = search['allMetadata'].concat(search.expandedThemeTag)
 
   return search
 }

--- a/scripts/gatsby-source-iiif/indexSearch.js
+++ b/scripts/gatsby-source-iiif/indexSearch.js
@@ -11,6 +11,8 @@ const getLanguages = require('./src/getLanguages')
 const findThumbnail = require('./src/findThumbnail')
 const additionalRecursiveSearchIds = ['BPP1001_EAD']
 
+const pruneEmptyLeaves = require('../../@ndlib/gatsby-theme-marble/src/utils/pruneEmptyLeaves')
+
 const appConfig = process.env.APP_CONFIG
 if (appConfig === 'local' || process.env.TRAVIS_RUN) {
   return
@@ -95,7 +97,7 @@ const loadSubItemTitles = (manifest) => {
   }
 
   return manifest.items.reduce((titles, item) => {
-    if (item.title) {
+    if (item.title && item.level !== 'file') {
       return titles + '::' + item.title
     }
     return titles
@@ -382,6 +384,7 @@ new Promise(async (resolve, reject) => {
   let writeData = []
   manifests.forEach((manifest) => {
     if (manifest) {
+      pruneEmptyLeaves(manifest)
       writeData.push(getSearchDataFromManifest(manifest))
       // if (manifest.hierarchySearchable || additionalRecursiveSearchIds.includes(manifest.id)) {
       const children = recursiveSearchDataFromManifest(manifest)

--- a/scripts/gatsby-source-iiif/indexSearch.js
+++ b/scripts/gatsby-source-iiif/indexSearch.js
@@ -16,10 +16,13 @@ if (appConfig === 'local' || process.env.TRAVIS_RUN) {
   return
 }
 
-const getCollection = (collection) => {
-  if (collection) {
-    return collection.map((c) => c.display)
+const getCollection = (collectionName, collection) => {
+  if (collectionName) {
+    return collectionName.map((c) => c.display)
+  } else if (collection) {
+    return [collection.title]
   }
+
   return []
 }
 
@@ -115,7 +118,7 @@ const getIdentifiers = (manifest) => {
   return ret
 }
 
-const getSearchDataFromManifest = (manifest) => {
+const getSearchDataFromManifest = (manifest, collection) => {
   const dateData = realDatesFromCatalogedDates(manifest.createdDate)
   const creators = getCreators(manifest)
   const themes = getKeywordsFromSubjects(manifest)
@@ -124,7 +127,7 @@ const getSearchDataFromManifest = (manifest) => {
     id: manifest.id,
     name: manifest.title,
     creator: creators,
-    collection: getCollection(manifest.collections),
+    collection: getCollection(manifest.collections, collection),
     identifier: getIdentifiers(manifest),
 
     repository: determineProvider(manifest),
@@ -353,15 +356,19 @@ const configIndexMappings = async () => {
   return mappings
 }
 
-const recursiveSearchDataFromManifest = (manifest) => {
+const recursiveSearchDataFromManifest = (manifest, collection) => {
   let ret = []
   if (!manifest.items) {
     return ret
   }
+  if (!collection) {
+    collection = manifest
+  }
+
   manifest.items.forEach(item => {
     if (item.level !== 'file') {
-      ret.push(getSearchDataFromManifest(item))
-      ret = ret.concat(recursiveSearchDataFromManifest(item))
+      ret.push(getSearchDataFromManifest(item, collection))
+      ret = ret.concat(recursiveSearchDataFromManifest(item, collection))
     }
   })
   return ret


### PR DESCRIPTION
This fixes a couple of things.

1.  The collection name now appears in child records when they are displayed in search.  It has highlight hits as well. 
2.  Fixed the case where hits in all metadata did not always have a line break between them.  
3.  Ensure prune is called here too.  