### PR TITLE
Update Sibling Items to display pdf icon correctly

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SiblingItems/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SiblingItems/index.js
@@ -8,6 +8,7 @@ import typy from 'typy'
 import DisplayViewToggle from 'components/Internal/DisplayViewToggle'
 import ManifestCard from 'components/Shared/ManifestCard'
 import getArrayNeighbors from 'utils/getArrayNeighbors'
+import findImage from 'utils/findImage'
 
 const SiblingItems = ({ marbleItem, numberBeforeAndAfter }) => {
   const siblings = typy(marbleItem, 'marbleParent.childrenMarbleItem').safeArray
@@ -35,7 +36,7 @@ const SiblingItems = ({ marbleItem, numberBeforeAndAfter }) => {
                 <ManifestCard
                   key={sibling.slug}
                   target={sibling.slug}
-                  image={typy(sibling, 'childrenMarbleFile[0].iiif.thumbnail').safeString}
+                  image={findImage(sibling.childrenMarbleFile, sibling, true)}
                   label={sibling.title}
                   showSummary
                 />

--- a/@ndlib/gatsby-theme-marble/src/templates/marbleItem.js
+++ b/@ndlib/gatsby-theme-marble/src/templates/marbleItem.js
@@ -52,6 +52,7 @@ export const query = graphql`
           title
           slug
           childrenMarbleFile {
+            fileType
             iiif {
               thumbnail
             }

--- a/scripts/gatsby-source-iiif/src/findThumbnail/index.js
+++ b/scripts/gatsby-source-iiif/src/findThumbnail/index.js
@@ -1,10 +1,12 @@
+const imageExtension = new RegExp('.(tiff|tif|jpg|jpeg|png|webp)$')
 
 module.exports = (manifest) => {
   return depthFirstSearchForThumbnails(manifest)
 }
 
 const depthFirstSearchForThumbnails = (manifest) => {
-  if (manifest.iiifImageUri) {
+  // make sure there is an iiifImageUri and it is a valid image format (NO PDF)
+  if (manifest.iiifImageUri && (imageExtension.test(manifest.filePath) || imageExtension.test(manifest.defaultFilePath))) {
     return manifest.iiifImageUri + '/full/!250,250/0/default.jpg'
   }
 

--- a/scripts/gatsby-source-iiif/src/findThumbnail/index.js
+++ b/scripts/gatsby-source-iiif/src/findThumbnail/index.js
@@ -4,6 +4,7 @@ module.exports = (manifest) => {
   return depthFirstSearchForThumbnails(manifest)
 }
 
+// eslint-disable-next-line complexity
 const depthFirstSearchForThumbnails = (manifest) => {
   // make sure there is an iiifImageUri and it is a valid image format (NO PDF)
   if (manifest.iiifImageUri && (imageExtension.test(manifest.filePath) || imageExtension.test(manifest.defaultFilePath))) {


### PR DESCRIPTION
* Use the same findImage function as used other places to accomplish the same thing.
* Also update indexSearch's image check to make sure extension is valid.