### PR TITLE
MARBLE-1338 Cover image needs shown on collection pages

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Pages/MarbleItem/CollectionLayout/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Pages/MarbleItem/CollectionLayout/index.js
@@ -5,10 +5,13 @@ import Column from 'components/Shared/Column'
 import ActionButtonGroup from 'components/Shared/ActionButtonGroup'
 import ManifestDescription from 'components/Shared/ManifestDescription'
 import ManifestMetaData from 'components/Shared/ManifestMetaData'
+import ManifestImageGroup from 'components/Shared/ManifestImageGroup'
 import ChildManifests from 'components/Shared/ChildManifests'
 import PartiallyDigitized from 'components/Shared/PartiallyDigitized'
 
 const CollectionLayout = ({ marbleItem, location }) => {
+  const headerItem = marbleItem.childrenMarbleFile ?
+    marbleItem.childrenMarbleFile[0] : null
   return (
     <>
       <MultiColumn columns='5'>
@@ -19,6 +22,12 @@ const CollectionLayout = ({ marbleItem, location }) => {
           <PartiallyDigitized marbleItem={marbleItem} />
         </Column>
         <Column colSpan='3'>
+          {headerItem ? (
+            <ManifestImageGroup
+              location={location}
+              marbleItem={marbleItem}
+            />
+          ) : null}
           <ChildManifests
             marbleItem={marbleItem}
             location={location}

--- a/@ndlib/gatsby-theme-marble/src/components/Pages/MarbleItem/CollectionLayout/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Pages/MarbleItem/CollectionLayout/index.js
@@ -10,8 +10,8 @@ import ChildManifests from 'components/Shared/ChildManifests'
 import PartiallyDigitized from 'components/Shared/PartiallyDigitized'
 
 const CollectionLayout = ({ marbleItem, location }) => {
-  const headerItem = marbleItem.childrenMarbleFile ?
-    marbleItem.childrenMarbleFile[0] : null
+  const headerItem = marbleItem.childrenMarbleFile ? (
+    marbleItem.childrenMarbleFile[0]) : null
   return (
     <>
       <MultiColumn columns='5'>

--- a/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/makeMetadataArray.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/mapStandardJson/makeMetadataArray.js
@@ -45,7 +45,7 @@ const listAll = (standardJson, id) => {
         renderedList += (renderedList !== '' ? ', ' + val : val)
       }
     })
-    return [renderedList]
+    return (renderedList === '' ? false : [renderedList])
   }
   return false
 }


### PR DESCRIPTION
Addition of Cover Image to collection pages. Due to the current change in data storage, this will need revisited. Currently just showing first child item in list as default image.