### PR TITLE
suggestion for fixing the link color issue.  

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/assets/theme.js
+++ b/@ndlib/gatsby-theme-marble/src/assets/theme.js
@@ -111,6 +111,9 @@ export const theme = {
     Main: {
       margin: '0 auto',
       width: '100%',
+      '& a': {
+        color: 'primary',
+      },
     },
     Footer: {
       backgroundColor: 'secondary',
@@ -129,7 +132,6 @@ export const theme = {
       },
     },
     a: {
-      color: 'primary',
       wordBreak: 'break-word',
     },
     h1: {


### PR DESCRIPTION
Basically since the theme ui update we had to add theme.styles to the individual tags in the site. 

I can add this to the main class to catch all As in the main section without conflicting with the header and footer. 

