### PR TITLE
MARBLE-1472 Implement Cache for Source Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,5 @@ typings/
 .cache
 
 .DS_Store
-sites/marble
+
+.vscode

--- a/@ndlib/gatsby-source-appsync-marble-standard/gatsby-node.js
+++ b/@ndlib/gatsby-source-appsync-marble-standard/gatsby-node.js
@@ -15,10 +15,10 @@ exports.sourceNodes = async ({ actions, createContentDigest, cache }, pluginOpti
   const cachedList = await cache.get('standardItemListCacheKey')
   let itemList
   if (cachedList) {
-    console.log('Have a cached list of items.')
+    // console.log('Have a cached list of items.')
     itemList = cachedList
   } else {
-    console.log('Do not have a cached list of items.')
+    // console.log('Do not have a cached list of items.')
     itemList = await getListOfItems(pluginOptions)
   }
   await cache.set('standardItemListCacheKey', itemList)
@@ -28,10 +28,10 @@ exports.sourceNodes = async ({ actions, createContentDigest, cache }, pluginOpti
   const cachedStandardEverything = await cache.get('standardItemsCachedKey')
   let everything
   if (cachedStandardEverything) {
-    console.log('Have a giant cache blob of everything.')
+    // console.log('Have a giant cache blob of everything.')
     everything = cachedStandardEverything
   } else {
-    console.log('Need to fetch everything.')
+    // console.log('Need to fetch everything.')
     const progressBar = new cliProgress.SingleBar({
       format: '{bar} {percentage}% || {value}/{total} Top Level Items',
       barCompleteChar: '\u2588',

--- a/@ndlib/gatsby-source-appsync-marble-standard/gatsby-node.js
+++ b/@ndlib/gatsby-source-appsync-marble-standard/gatsby-node.js
@@ -4,38 +4,53 @@ const getItems = require('./src/getItems')
 const macDNS = require('./src/macDNS')
 // const writeDebug = require('./src/writeDebug')
 
-exports.sourceNodes = async ({ actions, createContentDigest }, pluginOptions) => {
-  console.time('total time')
-  console.time('fetch items')
+exports.sourceNodes = async ({ actions, createContentDigest, cache }, pluginOptions) => {
+  const { createNode, touchNode } = actions
   const { url, key, website } = pluginOptions
   await macDNS(url)
 
-  const { createNode } = actions
-  const itemList = await getListOfItems(pluginOptions)
-  // const itemList = [
-  //   { itemId: 'BPP1001_EAD' },
-  //   { itemId: 'MSNCW5066_EAD' },
-  //   { itemId: '2008.026.008' },
-  // ]
+  console.time('total time')
+  console.time('fetch items')
+
+  const cachedList = await cache.get('standardItemListCacheKey')
+  let itemList
+  if (cachedList) {
+    console.log('Have a cached list of items.')
+    itemList = cachedList
+  } else {
+    console.log('Do not have a cached list of items.')
+    itemList = await getListOfItems(pluginOptions)
+  }
+  await cache.set('standardItemListCacheKey', itemList)
+
   console.log('Total top level items: ', itemList.length)
 
-  const progressBar = new cliProgress.SingleBar({
-    format: 'Items Downloaded |' + '{bar}' + '| {percentage}% || {value}/{total} Items',
-    barCompleteChar: '\u2588',
-    barIncompleteChar: '\u2591',
-    hideCursor: true,
-  })
-  progressBar.start(itemList.length, 0, {
-    speed: 'N/A',
-  })
-  const everything = await getItems({
-    url: url,
-    itemList: itemList,
-    website: website,
-    key: key,
-    progressBar: progressBar,
-  })
-  progressBar.stop()
+  const cachedStandardEverything = await cache.get('standardItemsCachedKey')
+  let everything
+  if (cachedStandardEverything) {
+    console.log('Have a giant cache blob of everything.')
+    everything = cachedStandardEverything
+  } else {
+    console.log('Need to fetch everything.')
+    const progressBar = new cliProgress.SingleBar({
+      format: '{bar} {percentage}% || {value}/{total} Top Level Items',
+      barCompleteChar: '\u2588',
+      barIncompleteChar: '\u2591',
+      hideCursor: true,
+    })
+    progressBar.start(itemList.length, 0, {
+      speed: 'N/A',
+    })
+    everything = await getItems({
+      url: url,
+      itemList: itemList,
+      website: website,
+      key: key,
+      progressBar: progressBar,
+    })
+    progressBar.stop()
+  }
+  await cache.set('standardItemsCachedKey', everything)
   console.timeEnd('fetch items')
   // await writeDebug(everything)
   console.time('generate standard nodes')
@@ -51,6 +66,7 @@ exports.sourceNodes = async ({ actions, createContentDigest }, pluginOptions) =>
       }
       const node = Object.assign({}, item, nodeMeta)
       createNode(node)
+      touchNode(node)
     }
   })
   console.timeEnd('generate standard nodes')

--- a/@ndlib/gatsby-source-appsync-marble-standard/src/getItems.js
+++ b/@ndlib/gatsby-source-appsync-marble-standard/src/getItems.js
@@ -1,6 +1,5 @@
 const fetch = require('isomorphic-fetch')
 const batchPromises = require('batch-promises')
-const cliProgress = require('cli-progress')
 const queryItem = require('./queryItem')
 
 const getItems = async ({

--- a/@ndlib/gatsby-transformer-marbleitem/gatsby-node.js
+++ b/@ndlib/gatsby-transformer-marbleitem/gatsby-node.js
@@ -1,25 +1,19 @@
 const pruneEmptyLeaves = require('./src/pruneEmptyLeaves')
 const { crawlStandardJson } = require('./src/crawlStandardJson')
 
-async function onCreateNode ({
-  node,
-  actions,
-  createNodeId,
-  createContentDigest,
-  getNode,
-}, pluginOptions = { skipMetadataPrune: false }) {
-  if (node.internal.type === 'StandardJson' || node.internal.type === 'AppSyncStandard') {
+exports.sourceNodes = async (
+  gatsbyInternal,
+  pluginOptions,
+) => {
+  const { getNodesByType } = gatsbyInternal
+  const standardJsonNodes = getNodesByType('StandardJson')
+  const appsyncStandardNodes = getNodesByType('AppSyncStandard')
+  const standardNodes = [...standardJsonNodes, ...appsyncStandardNodes]
+
+  standardNodes.forEach(node => {
     if (!pluginOptions.skipMetadataPrune) {
       pruneEmptyLeaves(node)
     }
-    crawlStandardJson(node, null, null, {
-      node: node,
-      actions: actions,
-      createNodeId: createNodeId,
-      createContentDigest: createContentDigest,
-      getNode: getNode,
-    })
-  }
+    crawlStandardJson(node, null, null, gatsbyInternal)
+  })
 }
-
-exports.onCreateNode = onCreateNode


### PR DESCRIPTION
* Add caching to `gatsby-source-appsync-marble-standard` plugin.
* Move node creation in `gatsby-transformer-marbleitem` so that `MarbleItem` nodes do not get garbage collected.