### PR TITLE
Apply word wrap to annotation

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/CalloutBox/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/CalloutBox/index.js
@@ -14,6 +14,7 @@ const CalloutBox = ({ children }) => {
         margin: '2rem auto',
         maxWidth: ['100%', '100%', '80%'],
         padding: '1rem',
+        wordWrap: 'break-word',
       }}>{children}</div>
   )
 }


### PR DESCRIPTION
MARBLE-1622 Apply word wrap formatting to Annotation section. If it is found that this is also needed elsewhere, the individual sx will need updated.
<img width="1280" alt="Screen Shot 2021-05-13 at 1 53 03 PM" src="https://user-images.githubusercontent.com/38439231/118165996-f3e10500-b3f2-11eb-87e1-fadc7e4d4832.png">
