### PR TITLE
Add footer option to modals. Fix scrollbar in modal overlapping header.

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/assets/theme.js
+++ b/@ndlib/gatsby-theme-marble/src/assets/theme.js
@@ -195,6 +195,18 @@ const theme = merge({}, bootstrapTheme, {
         color: 'primary',
       },
     },
+    text: {
+      backgroundColor: 'transparent',
+      border: 'none',
+      color: 'primaryBright',
+      cursor: 'pointer',
+      textDecoration: 'none',
+      padding: '0',
+      wordBreak: 'break-word',
+      ':hover': {
+        textDecoration: 'underline',
+      },
+    },
   },
   sections: {
     default: {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionModal/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionModal/index.js
@@ -12,6 +12,7 @@ const ActionModal = ({
   isOpen,
   closeFunc,
   fullscreen = false,
+  footer,
   children,
 }) => {
   const context = useThemeUI()
@@ -55,7 +56,12 @@ const ActionModal = ({
         </button>
       </div>
       <BaseStyles>
-        <div sx={sx.content}>{children}</div>
+        <div sx={sx.container}>
+          <div sx={bodyStyle(!!footer)}>{children}</div>
+          {footer && (
+            <div sx={sx.footer}>{footer}</div>
+          )}
+        </div>
       </BaseStyles>
     </ReactModal>
   )
@@ -66,6 +72,7 @@ ActionModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   closeFunc: PropTypes.func.isRequired,
   fullscreen: PropTypes.bool,
+  footer: PropTypes.node,
   children: PropTypes.node,
 }
 
@@ -92,5 +99,12 @@ export const modalStyle = (fullscreen) => {
       width: fullscreen ? '95vw' : '500px',
       maxWidth: '95vw',
     },
+  }
+}
+
+export const bodyStyle = (hasFooter) => {
+  return {
+    ...sx.body,
+    paddingBottom: hasFooter ? '0' : '1rem',
   }
 }

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionModal/sx.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionModal/sx.js
@@ -3,7 +3,7 @@ module.exports = {
     backgroundColor: 'primary',
     display: 'block',
     overflow: 'hidden',
-    position: 'absolute',
+    position: 'relative',
     width: '100%',
     zIndex: '1',
   },
@@ -35,12 +35,20 @@ module.exports = {
   svg: {
     verticalAlign: 'middle',
   },
-  content: {
-    maxHeight: 'calc(100vh - 80px - 3rem)',
-    marginTop: '3rem',
-    padding: '1rem',
-    overflowX: 'hidden',
-    overflowY: 'scroll',
+  container: {
+    display: 'flex',
+    flexFlow: 'column nowrap',
+    alignItems: 'stretch',
+    maxHeight: 'calc(100vh - 80px - 3.5rem)',
     position: 'relative',
+  },
+  body: {
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    position: 'relative',
+    padding: '1rem',
+  },
+  footer: {
+    padding: '1rem',
   },
 }


### PR DESCRIPTION
- Adds a "text" variant to button. Sometimes you want a "link" that opens a modal (or similar) instead of going to a different page. Rather than a hack that prevents an <a> tag from acting like a link that goes somewhere, it's better to just style a <button> to look like a link.
- Adds an optional footer to the ActionModal. This will always be visible at the bottom of the modal on screen, so you don't have to scroll down to find it if the modal contents are long. Helpful for keeping action buttons visible.
- Fixes an issue where the modal content was slightly overlapping the header, causing the spacing to be a little off and the scrollbar extending above the visible content box.