### PR TITLE
MARBLE-1707 breadcrumbs 

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,7 +5,7 @@ plugins:
       languages:
         javascript:
           filters:
-            - "(property (Identifier propTypes))"
+            - "(object (Identifier PropTypes))"
 exclude_paths:
 - "**/config/"
 - "**/node_modules/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,7 +5,7 @@ plugins:
       languages:
         javascript:
           filters:
-            - "s(:property, s(:Identifier, :propTypes))"
+            - "(property (Identifier propTypes))"
 exclude_paths:
 - "**/config/"
 - "**/node_modules/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,7 +2,7 @@ version: "2"
 checks:
   method-lines:
     config:
-      threshold: 75
+      threshold: 50
   similar-code:
     enabled: true
     config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,7 +5,7 @@ plugins:
       languages:
         javascript:
           filters:
-            - "(property (Identifier propTypes))"
+            - "s(property (Identifier propTypes))"
 exclude_paths:
 - "**/config/"
 - "**/node_modules/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,7 +5,7 @@ plugins:
       languages:
         javascript:
           filters:
-            - "s(property (Identifier propTypes))"
+            - "s(:property, s(:Identifier, :propTypes))"
 exclude_paths:
 - "**/config/"
 - "**/node_modules/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,7 +2,7 @@ version: "2"
 checks:
   method-lines:
     config:
-      threshold: 100
+      threshold: 75
   similar-code:
     enabled: true
     config:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,12 @@
 version: "2"
+checks:
+  method-lines:
+    config:
+      threshold: 100
+  similar-code:
+    enabled: true
+    config:
+      threshold: 80
 plugins:
   duplication:
     config:

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Breadcrumbs/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Breadcrumbs/index.js
@@ -5,6 +5,27 @@ import PropTypes from 'prop-types'
 import Link from 'components/Shared/Link'
 import { jsx } from 'theme-ui'
 
+/*
+  Class to add a ND theme breadcrumbs to a page.
+  props:
+  variant - default the style variant for changing propeties in the theme-ui. currently theme only supports default
+  breadcrumbs   - array of objects in the format of [ {url, title} ... ].
+  currentPageTitle   - the page title to put at the end
+  Breadcrumbs:
+     can have several parameters.
+      -url a link for the a tag.
+      -title for the link.
+     Do not include home or the current page.
+     Add currentPageTitle for the page title
+  Trimmed titles:
+    Titles > 60 chars get trimed on several characters see trimTitle
+    If they are still > 60 chars they get truncated
+  Theme UI Variant.
+    writes a variant called links.${variant}
+    Can be edited in the theme.
+  Examples of existing variants
+    default:
+*/
 export const NDBrandBreadcrumbs = ({ variant, breadcrumbs, currentPageTitle, ...props }) => {
   const sx = {
     pl: 0,
@@ -13,19 +34,35 @@ export const NDBrandBreadcrumbs = ({ variant, breadcrumbs, currentPageTitle, ...
     listStyle: 'none',
     fontSize: 0,
     '& li': {
-      display: 'inline-block',
+      display: ['none', 'none', 'none', 'inline-block'],
       mr: '0.75rem',
+      '&:nth-last-child(2)': {
+        display: 'inline-block',
+      },
     },
+
   }
   return (
     <ol varaint={'breadcrumbs.' + variant} sx={sx} {...props}>
       <li><Link variant='breadcrumb' to='/'>Home</Link> › </li>
       {breadcrumbs.map((item) => {
-        return (<li key={item.url}><Link variant='breadcrumb' to={item.url}>{item.title}</Link>›</li>)
+        return (<li key={item.url}><Link variant='breadcrumb' to={item.url}>{trimTitle(item.title)}</Link>›</li>)
       })}
-      <li>{currentPageTitle} › </li>
+      <li>{trimTitle(currentPageTitle)} › </li>
     </ol>
   )
+}
+
+const trimTitle = (title) => {
+  if (title.length > 60) {
+    const splitTitle = title.split(/[:_([]/)
+    if (splitTitle[0].length > 60) {
+      // match the first 60 characters up to a space or end of line
+      return splitTitle[0].match(/.{1,60}(\s|$)/g)[0].trim() + '...'
+    }
+    return splitTitle[0].trim()
+  }
+  return title
 }
 
 NDBrandBreadcrumbs.propTypes = {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Breadcrumbs/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Breadcrumbs/index.js
@@ -58,6 +58,7 @@ const trimTitle = (title) => {
     const splitTitle = title.split(/[:_([]/)
     if (splitTitle[0].length > 60) {
       // match the first 60 characters up to a space or end of line
+      // note that if the characters do not have a space in it it will choose the last chars up that space.
       return splitTitle[0].match(/.{1,60}(\s|$)/g)[0].trim() + '...'
     }
     return splitTitle[0].trim()

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Breadcrumbs/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Breadcrumbs/test.js
@@ -52,3 +52,12 @@ test('truncates the titles at 60 chars and trims space if the 60th char is a spa
   const wrapper = shallow(<NDBrandBreadcrumbs breadcrumbs={bcs} currentPageTitle={longTitle} />)
   expect(wrapper.find('li').last().props()).toEqual(test)
 })
+
+test('truncates the titles at 60 chars even if it has already split at a special character', () => {
+  const longTitle = 'superlong title that will get split because that is what we want : with a special char.'
+  const test = { children:  ['superlong title that will get split because that is what we...', ' › '] }
+  const bcs = []
+
+  const wrapper = shallow(<NDBrandBreadcrumbs breadcrumbs={bcs} currentPageTitle={longTitle} />)
+  expect(wrapper.find('li').last().props()).toEqual(test)
+})

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Breadcrumbs/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Breadcrumbs/test.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { NDBrandBreadcrumbs } from './'
+
+test('Breadcrumb add home link', () => {
+  const test = { variant: 'breadcrumb', to: '/', children: 'Home' }
+  const bcs = []
+
+  const wrapper = shallow(<NDBrandBreadcrumbs breadcrumbs={bcs} currentPageTitle='page-title' />)
+  expect(wrapper.find('li').first().find('Link').props()).toEqual(test)
+})
+
+test('Breadcrumb adds middle levels', () => {
+  const test = { variant: 'breadcrumb', to: 'middle', children: 'middle' }
+  const bcs = [{ url: 'middle', title: 'middle' }]
+
+  const wrapper = shallow(<NDBrandBreadcrumbs breadcrumbs={bcs} currentPageTitle='page-title' />)
+  expect(wrapper.find('li').at(1).find('Link').props()).toEqual(test)
+})
+
+test('adds title to the end of the breadcrumbs', () => {
+  const test = { children:  ['page-title', ' › '] }
+  const bcs = []
+
+  const wrapper = shallow(<NDBrandBreadcrumbs breadcrumbs={bcs} currentPageTitle='page-title' />)
+  expect(wrapper.find('li').last().props()).toEqual(test)
+})
+
+test('truncates the titles at :_([', () => {
+  const longTitle = 'superlong title that will get split at : because that is what we want.'
+  const test = { children:  ['superlong title that will get split at', ' › '] }
+  const bcs = []
+
+  const wrapper = shallow(<NDBrandBreadcrumbs breadcrumbs={bcs} currentPageTitle={longTitle} />)
+  expect(wrapper.find('li').last().props()).toEqual(test)
+})
+
+test('truncates the titles at 60 chars if there are no split points', () => {
+  const longTitle = 'super long title that should get split somewhere because that is what we want.'
+  const test = { children:  ['super long title that should get split somewhere because...', ' › '] }
+  const bcs = []
+
+  const wrapper = shallow(<NDBrandBreadcrumbs breadcrumbs={bcs} currentPageTitle={longTitle} />)
+  expect(wrapper.find('li').last().props()).toEqual(test)
+})
+
+test('truncates the titles at 60 chars and trims space if the 60th char is a space', () => {
+  const longTitle = 'superlong title that will get split because that is what we want.'
+  const test = { children:  ['superlong title that will get split because that is what we...', ' › '] }
+  const bcs = []
+
+  const wrapper = shallow(<NDBrandBreadcrumbs breadcrumbs={bcs} currentPageTitle={longTitle} />)
+  expect(wrapper.find('li').last().props()).toEqual(test)
+})


### PR DESCRIPTION
Update breadcrumbs to trim titles. 

Trys to trim at a few special chars.  
if it is still bigger than 60 trim at the last space within 60 chars.  

Updated style to only show the immediate parent crumb when the screens are small. 

Added tests and class declaration.  