### PR TITLE
update card sizes so that they are narrow in small screens.

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/Card/sx.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/Card/sx.js
@@ -31,7 +31,8 @@ module.exports = {
       '& em': {
         backgroundColor: 'highlight',
       },
-      height: '250px',
+      height: ['435px', '435px', '250px'],
+      overflow: ['hidden', 'hidden', 'inherit'],
       position: 'relative',
     } : {
       '& em': {
@@ -40,7 +41,6 @@ module.exports = {
       height: '435px',
       overflow: 'hidden',
       position: 'relative',
-
     }
   },
   imageBoarder: {
@@ -63,10 +63,11 @@ module.exports = {
   },
   imageWrapper: (wide) => {
     return wide ? {
-      display: 'inline-block',
+      display: ['block', 'block', 'inline-block'],
       verticalAlign: 'top',
-      width: '250px',
-    } : {}
+      width: ['', '', '250px'],
+    } : {
+    }
   },
   imageWrapperInner: {
     boxSizing: 'border-box',
@@ -79,13 +80,16 @@ module.exports = {
     return wide ? {
       borderBottom: '6px solid',
       borderColor: 'primary',
-      display: 'inline-block',
-      height: '265px',
-      marginLeft: '1.5rem',
-      overflow: 'hidden',
+      display: ['block', 'block', 'inline-block'],
+      height: ['170px', '170px', '265px'],
+      marginLeft: [0, 0, '1.5rem'],
       padding: '.5rem',
+      overflow: 'hidden',
       position: 'relative',
-      width: 'calc(100% - 250px - 1.5rem)',
+      width: ['100%', '100%', 'calc(100% - 250px - 1.5rem)'],
+      '& div': {
+        display: ['none', 'block', 'block'],
+      },
     } : {
       borderBottom: '6px solid',
       borderColor: 'primary',
@@ -93,6 +97,9 @@ module.exports = {
       overflow: 'hidden',
       padding: '.5rem',
       position: 'relative',
+      '& div': {
+        display: ['none', 'block', 'block'],
+      },
     }
   },
   label: {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/CardGroup/CardGroupToggle/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/CardGroup/CardGroupToggle/index.js
@@ -37,7 +37,7 @@ export const CardGroupToggle = ({ toggleGroup, layout, extraControls }) => {
       <Box sx={{ width: '100%', py: '2px', paddingRight: '5px' }}>
         {extraControls}
       </Box>
-      <Box sx={{ minWidth: '68px' }}>
+      <Box sx={{ minWidth: '68px', display: ['none', 'none', 'block'] }}>
         {
           options.map(opt => {
             const isActive = (layout === opt.display)

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/CardGroup/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/CardGroup/index.js
@@ -36,7 +36,7 @@ export const CardGroup = ({ toggleGroup, extraControls, children, allowToggle, d
       width: ['100%'],
     },
     grid: {
-      width: ['100%', '50%', '50%', '33.33%'],
+      width: ['100%', '100%', '50%', '50%', '33.33%'],
       padding: '1rem',
     },
   }

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/index.js
@@ -41,6 +41,7 @@ SearchResults.propTypes = {
   hitsPerPage: PropTypes.number,
   showPagination: PropTypes.bool,
   scrollTo: PropTypes.string,
+  extraControls: PropTypes.node,
 }
 
 SearchResults.defaultProps = {


### PR DESCRIPTION
1.  Made the wide view of the card revert to a narrow vertical card on the 2 smallest screens.  
2. Removed the ability to toggle a display between wide and vertical. 
3. expand the breakpoints for the grid view by one break point to attempt to have fewer crowded grid cards.  

