### PR TITLE
Fix font color of clipboard notification

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ShareButton/ShareModalContent/sx.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ShareButton/ShareModalContent/sx.js
@@ -19,7 +19,7 @@ module.exports = {
     verticalAlign: 'top',
   },
   copied: {
-    color: 'gray.2',
+    color: 'gray.4',
     display: 'block',
     fontSize: '.75rem',
     padding: '.25rem 0',


### PR DESCRIPTION
MARBLE-1831, darken the grey color of the "Copied to clipboard" text.