### PR TITLE
Fix error when account does not exist

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/store/actions/loginActions/index.js
+++ b/@ndlib/gatsby-theme-marble/src/store/actions/loginActions/index.js
@@ -118,13 +118,13 @@ export const storeAuthenticationAndGetLogin = (idToken, loginReducer) => {
       if (response.status >= 200 && response.status < 400) {
         return response.json()
       }
-    }).catch(() => {
-      return dispatch(noUser())
     }).then(json => {
-      if (!json.userName) {
+      if (!json?.userName) {
         return dispatch(noUser())
       }
       return dispatch(logUserIn(json))
+    }).catch(() => {
+      return dispatch(noUser())
     })
   }
 }


### PR DESCRIPTION
If you don't have an account, the login reducer is supposed to receive NO_USER and allow you to create an account. In reality, it was throwing an exception because it could not evaluate `json.userName` since `json` can be undefined.