### PR TITLE
Don't display horizontal scrollbar when not necessary.

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/assets/theme.js
+++ b/@ndlib/gatsby-theme-marble/src/assets/theme.js
@@ -280,7 +280,7 @@ const theme = merge(bootstrapTheme, {
       },
       '& div.sectionContent': {
         py: '2rem',
-        width: '90vw',
+        width: '100%',
       },
     },
     fullBleedDark: {
@@ -293,7 +293,7 @@ const theme = merge(bootstrapTheme, {
       },
       '& div.sectionContent': {
         py: '4rem',
-        width: '90vw',
+        width: '100%',
       },
     },
   },
@@ -346,7 +346,7 @@ const theme = merge(bootstrapTheme, {
       maxWidth: '65rem',
     },
     fullBleed: {
-      maxWidth: '100vw',
+      maxWidth: '100%',
     },
   },
   links: {
@@ -500,7 +500,7 @@ const theme = merge(bootstrapTheme, {
       mr: '5vw',
       '& div': {
         display: 'flex',
-        minWidth: ['100vw', '100vw', '100vw', '550px'],
+        minWidth: ['100%', '100%', '100%', '550px'],
         justifyContent: ['space-around', 'space-around', 'space-around', 'flex-start'],
         opacity: '1',
         transition: 'all 1s',

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Header/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Header/index.js
@@ -48,18 +48,19 @@ export const NDBrandHeader = ({ location, variant, titleOverride, menuItems, sho
     <Box as='header' sx={{
       variant: variant,
       gridRow: 'header',
-      width: '100vw',
+      width: '100%',
       opacity: '1',
       zIndex: 1,
     }}>
-      <Box className='titleContainer' sx={{ display: ['block', 'block', 'flex'], width: '100vw', flexDirection: 'row-reverse', justifyContent: 'space-between' }}>
+      <Box className='titleContainer' sx={{ display: ['block', 'block', 'flex'], width: '100%', flexDirection: 'row-reverse', justifyContent: 'space-between' }}>
         <div className='mark' sx={{
-          width: ['100vw', '100vw', '200px'],
+          width: ['100%', '100%', '200px'],
           bg: ['primaryDark', 'primaryDark', 'primary'],
           mx: ['auto', 'auto', '5vw'],
           display: ['flex', 'flex', 'block'],
           justifyContent: ['center', 'center', 'inherit'],
-          py: ['15px', '15px', '0'] }}
+          py: ['15px', '15px', '0'],
+        }}
         >
           <ClickableNDLogoWhite sx={{ display: ['none', 'none', 'block'] }} />
           <img
@@ -86,7 +87,7 @@ export const NDBrandHeader = ({ location, variant, titleOverride, menuItems, sho
         </div>
       </Box>
       <Box className='nav' sx={{ maxHeight: ['75px', '75px', '75px', 0] }}>
-        <Box as='nav' sx={{ variant: `menus.navTop` }}>
+        <Box as='nav' sx={{ variant: 'menus.navTop' }}>
           <div>
             {!showSearch ? (
               menuItems

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Hero/FullBleed/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Hero/FullBleed/index.js
@@ -26,10 +26,12 @@ export const NDBrandHeroFullBleed = ({ variant, image, title, button, link, attr
         display: ['none', 'none', 'none', 'block'],
       }}>
         {title ? (<Heading as='h2' variant='pageTitle' sx={{ ml: '5vw', mt: '.75rem', alignSelf: 'flex-end', fontSize: 6 }}>{title}</Heading>) : null }
-        {button ? (
-          <Flex sx={{ alignItems: 'end', justifyItems: 'end', width: '100%', flexDirection: 'row', pl: '5vw' }}>
-            {button}
-          </Flex>) : null }
+        {button
+          ? (
+            <Flex sx={{ alignItems: 'end', justifyItems: 'end', width: '100%', flexDirection: 'row', pl: '5vw' }}>
+              {button}
+            </Flex>)
+          : null }
       </Flex>
       <div sx={{
         gridRow: '1/-1',
@@ -39,7 +41,7 @@ export const NDBrandHeroFullBleed = ({ variant, image, title, button, link, attr
       }}>
         <Link to={link} title={attribution}>
           {image}
-          {attribution ? (<span sx={{ position: 'relative', bottom: '1.3rem', color: 'white', left: '75vw', px:'1rem', bg: 'gray.8' }}>{attribution}</span>) : null}
+          {attribution ? (<span sx={{ position: 'relative', bottom: '1.45rem', right: '10vw', float: 'right', marginLeft: '6rem', color: 'white', px:'1rem', bg: 'gray.8' }}>{attribution}</span>) : null}
         </Link></div>
     </Box>
 

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Layout/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Layout/index.js
@@ -115,7 +115,7 @@ const NDBrandLayout = ({ location, variant, children, pageHeader, siteFooter, ti
       }} key='toggle-search' onClick={() => setShowSearch(!showSearch)} title='show search'>
       <FaSearch />
       <span>Search</span>
-    </Button>)
+    </Button>),
   )
   items.push((
     <Button
@@ -134,7 +134,7 @@ const NDBrandLayout = ({ location, variant, children, pageHeader, siteFooter, ti
       ref={menuButtonRef}
     >
       { showMenu ? <FaTimes /> : (<><FaGripLines /><span>Menu</span></>) }
-    </Button>)
+    </Button>),
   )
 
   return (
@@ -175,7 +175,7 @@ const NDBrandLayout = ({ location, variant, children, pageHeader, siteFooter, ti
               position: 'absolute',
               top: '0',
               bottom: '0',
-              left: '70vw',
+              right: '0',
               width: '30vw',
               zIndex: '-1',
               background: '#fff',

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Section/LeftNav/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/NDBrand/Section/LeftNav/index.js
@@ -10,7 +10,7 @@ export const NDBrandSectionLeftNav = ({ variant, children, ...props }) => {
       variant={`sections.${variant}`}
       as='section'
       gap={'0'}
-      columns={['0 100vw', '0 100vw', '0 100vw', '22vw 77vw']}
+      columns={['0 100%', '0 100%', '0 100%', '23% 77%']}
       {...props}
     >
       {children}


### PR DESCRIPTION
Using `vw` for layout is an issue when you assume that the page width should equal `100vw`. The browser may interpret view width to include the space where the vertical scrollbar is. This in turn causes the page contents to extend outside the boundaries of what is "visible", so you end up with a horizontal scrollbar for that little extra width. Most layout elements should be sized relative to their parent anyway. If you were to set a max-width on the parent container, you want it to fill the space within the bounds of the parent, not go beyond it because 90vw or 100vw happens to be wider.

This also fixes an issue with the attribution on the front page. It was previously anchored to the left which meant it could extend too far to the right and again create a scrollbar. This change anchors it to the right, and sets a margin on the left so the text will stay on screen even if it takes multiple lines.