### PR TITLE
Implement cutoff date for century tags.

### DIFF
--- a/@ndlib/gatsby-source-appsync-marble/src/getItems/transform/formatSearchData/index.js
+++ b/@ndlib/gatsby-source-appsync-marble/src/getItems/transform/formatSearchData/index.js
@@ -8,8 +8,9 @@ const getLanguages = require('../searchData/getLanguages')
 const getKeywordsFromSubjects = require('../searchData/getKeywordsFromSubjects')
 const getThumbnail = require('../searchData/getThumbnail')
 
-module.exports = async (item) => {
-  const dateData = realDatesFromCatalogedDates(item.createdDate)
+module.exports = async (item, pluginOptions) => {
+  const { timePeriodCutoff } = pluginOptions
+  const dateData = realDatesFromCatalogedDates(item.createdDate, timePeriodCutoff)
   const creators = getCreators(item)
   const themes = getKeywordsFromSubjects(item)
   const allMetadataKeys = [

--- a/@ndlib/gatsby-source-appsync-marble/src/getItems/transform/index.js
+++ b/@ndlib/gatsby-source-appsync-marble/src/getItems/transform/index.js
@@ -21,7 +21,7 @@ module.exports = async (appSyncItem, gatsbyInternal, pluginOptions) => {
     parentId:  appSyncItem.parentId,
     partiallyDigitized: mapFieldOrDefault(appSyncItem, 'partiallyDigitized', false),
     sequence: appSyncItem.sequence,
-    searchData: await formatSearchData(appSyncItem),
+    searchData: await formatSearchData(appSyncItem, pluginOptions),
     slug: slug,
     title: appSyncItem.title,
   }

--- a/@ndlib/gatsby-source-appsync-marble/src/getItems/transform/searchData/realDatesFromCatalogedDates/test.js
+++ b/@ndlib/gatsby-source-appsync-marble/src/getItems/transform/searchData/realDatesFromCatalogedDates/test.js
@@ -10,6 +10,10 @@ test('takes a string year(s) and gets a highest and lowest values for it', () =>
     [1342, 1342, 1342],
     ['1900', 1900, 1900],
     ['250-400', 250, 400],
+    ['0-500', 0, 500],
+    ['75000-900 BCE', -75000, -900],
+    ['900 BCE-200 CE', -900, 200],
+    ['200 B.C.-100 A.D.', -200, 100],
     ['20th Century', 1900, 1999],
     ['1st century', 0, 99],
     ['2nd Century', 100, 199],
@@ -17,9 +21,9 @@ test('takes a string year(s) and gets a highest and lowest values for it', () =>
     ['mid-14th Century', 1333, 1366],
     ['late 5th Century', 467, 499],
     ['early 9th Century', 800, 832],
-    ['', 50000, -50000],
+    ['', 500000, -500000],
   ].forEach((testData) => {
-    const result = realDatesFromCatalogedDates(testData[0])
+    const result = realDatesFromCatalogedDates(testData[0], -500000)
     expect(result.lowestSearchRange).toEqual(testData[1])
     expect(result.highestSearchRange).toEqual(testData[2])
   })
@@ -33,7 +37,7 @@ test('It sets undated for undated dates', () => {
     [[], 'undated'],
     ['not a recognized date', ['undated']],
   ].forEach((testData) => {
-    const result = realDatesFromCatalogedDates(testData[0])
+    const result = realDatesFromCatalogedDates(testData[0], -500000)
     expect(result.undated).toEqual(true)
   })
 })
@@ -43,13 +47,16 @@ test('It sets circa for circa dates', () => {
   [
     ['ca. 1899-1900', ['ca. 1899-1900', '1450'], 'c. 1523-3212'],
   ].forEach((testData) => {
-    const result = realDatesFromCatalogedDates(testData[0])
+    const result = realDatesFromCatalogedDates(testData[0], -500000)
     expect(result.circa).toEqual(true)
   })
 })
 
 test('takes a string year and gets a tag for it', () => {
   [
+    ['500 BCE', ['500 BCE-401 BCE']],
+    ['200 BCE-0', ['200 BCE-101 BCE', '100 BCE-1 BCE', '0-99']],
+    ['0-300', ['0-99', '100-199', '200-299', '300-399']],
     ['1790-1890', ['1700-1799', '1800-1899']],
     ['1937.', ['1900-1999']],
     ['ca. 1899-1900', ['1800-1899', '1900-1999']],
@@ -75,7 +82,26 @@ test('takes a string year and gets a tag for it', () => {
     ['250-400', ['200-299', '300-399', '400-499']],
 
   ].forEach((testData) => {
-    const result = realDatesFromCatalogedDates(testData[0])
+    const result = realDatesFromCatalogedDates(testData[0], -500000)
+    expect(result.centuryTags).toEqual(testData[1])
+  })
+})
+
+test('groups together all dates which are before the cutoff year in a single tag', () => {
+  [
+    ['12400-1100 BCE', ['Pre-1000']],
+    ['1500-600 BCE', ['Pre-1000']],
+    ['500 BCE', ['Pre-1000']],
+    ['200 BCE-0', ['Pre-1000']],
+    ['0-300', ['Pre-1000']],
+    ['900-1050', ['Pre-1000', '1000-1099']],
+    ['1000-1100', ['1000-1099', '1100-1199']],
+    ['1790-1890', ['1700-1799', '1800-1899']],
+    ['ca. 200-800', ['Pre-1000']],
+    [999, ['Pre-1000']],
+    ['1900', ['1900-1999']],
+  ].forEach((testData) => {
+    const result = realDatesFromCatalogedDates(testData[0], 1000)
     expect(result.centuryTags).toEqual(testData[1])
   })
 })

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchRefinementListFilter/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchRefinementListFilter/index.js
@@ -9,6 +9,22 @@ export const listOrder = (list, sort) => {
     list.sort((a, b) => {
       return a.key && b.key ? a.key.localeCompare(b.key, undefined, { numeric: true }) : 0
     })
+  } else if (sort === 'century') {
+    list.sort((a, b) => {
+      if (!a.key || !b.key) {
+        return 0
+      } else if (a.key.startsWith('Pre-')) {
+        return -1
+      } else if (b.key.startsWith('Pre-')) {
+        return 1
+      }
+      const aBC = a.key.includes('BC')
+      const bBC = b.key.includes('BC')
+      // -1 if first item is BC; 1 if second item is BC; else 0
+      const eraDiff = bBC - aBC
+      const directionOperator = (aBC ? -1 : 1) // Inverts comparison when comparing BC dates; higher numbers first
+      return eraDiff || (a.key.localeCompare(b.key, undefined, { numeric: true }) * directionOperator)
+    })
   }
 
   return list


### PR DESCRIPTION
The goal of this change is to fully support BC dates, but also categorize anything before a certain date under a single tag. This happens to be 1400 right now, but the value is configurable so that another site could conceivably use a different value which makes more sense based on the age of items in that collection.

This should resolve all issues where items from "1500 BCE" get lumped in the "1500-1599" range. There would be a separate tag for "1500 BCE-1401 BCE", if the cutoff date were configured to something before then. (Represented with a negative number; e.g. -2000) Additionally, this fixes issues where 0 was not being identified as a valid year, so ranges like "0-500" were only being given the 500-599 tag.

In practice, both of those situations fall before the cutoff date we'll have configured for MARBLE right now, and will simply generate a tag called "Pre-1400".