### PR TITLE
MARBLE-1868 Update share modal styling

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionModal/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionModal/index.js
@@ -12,6 +12,7 @@ const ActionModal = ({
   isOpen,
   closeFunc,
   fullscreen = false,
+  short = false,
   footer,
   children,
 }) => {
@@ -55,7 +56,7 @@ const ActionModal = ({
           </svg>
         </button>
       </div>
-      <BaseStyles sx={sx.contentContainer}>
+      <BaseStyles sx={containerStyle({ short })}>
         <div sx={sx.flexContainer}>
           <div sx={bodyStyle(!!footer)}>{children}</div>
           {footer && (
@@ -72,6 +73,7 @@ ActionModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   closeFunc: PropTypes.func.isRequired,
   fullscreen: PropTypes.bool,
+  short: PropTypes.bool,
   footer: PropTypes.node,
   children: PropTypes.node,
 }
@@ -100,6 +102,14 @@ export const modalStyle = (fullscreen) => {
       maxWidth: '95vw',
     },
   }
+}
+
+export const containerStyle = ({ short }) => {
+  const style = sx.contentContainer
+  if (short) {
+    style.height = 'auto'
+  }
+  return style
 }
 
 export const bodyStyle = (hasFooter) => {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ActionModal/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ActionModal/index.js
@@ -105,11 +105,15 @@ export const modalStyle = (fullscreen) => {
 }
 
 export const containerStyle = ({ short }) => {
-  const style = sx.contentContainer
-  if (short) {
-    style.height = 'auto'
+  if (!short) {
+    return sx.contentContainer
   }
-  return style
+  return {
+    ...sx.contentContainer,
+    height: 'auto',
+    maxHeight: 'calc(100vh - 80px - 3.5rem)',
+    overflow: 'auto',
+  }
 }
 
 export const bodyStyle = (hasFooter) => {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ShareButton/ShareModalContent/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ShareButton/ShareModalContent/index.js
@@ -4,7 +4,7 @@ import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { useStaticQuery, graphql } from 'gatsby'
 import typy from 'typy'
-import { useThemeUI, jsx } from 'theme-ui'
+import { useThemeUI, jsx, Box } from 'theme-ui'
 import sx from './sx'
 
 const ShareModalContent = ({ path }) => {
@@ -25,14 +25,14 @@ const ShareModalContent = ({ path }) => {
   const context = useThemeUI()
   const iconColor = typy(context, 'theme.colors.background').safeString || '#fff'
   return (
-    <React.Fragment>
-      <label htmlFor={inputRef}>
+    <Box sx={{ margin: '1rem' }}>
+      <label>
         <input
           ref={inputRef}
           value={fullPath}
           onClick={() => onClick(inputRef, setIsCopied)}
           sx={sx.input}
-          aria-label={inputRef}
+          aria-label='Item URL'
           readOnly
         />
       </label>
@@ -57,15 +57,12 @@ const ShareModalContent = ({ path }) => {
           />
         </svg>
       </button>
-      {
-        isCopied ? (
-          <em
-            sx={sx.copied}
-          >Copied to clipboard
-          </em>
-        ) : null
-      }
-    </React.Fragment>
+      <em
+        sx={isCopied ? sx.copied : sx.copiedHidden}
+      >
+        Copied to clipboard
+      </em>
+    </Box>
   )
 }
 

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ShareButton/ShareModalContent/sx.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ShareButton/ShareModalContent/sx.js
@@ -19,7 +19,13 @@ module.exports = {
     verticalAlign: 'top',
   },
   copied: {
-    color: 'gray.4',
+    color: 'gray.6',
+    display: 'block',
+    fontSize: '.75rem',
+    padding: '.25rem 0',
+  },
+  copiedHidden: {
+    visibility: 'hidden',
     display: 'block',
     fontSize: '.75rem',
     padding: '.25rem 0',

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ShareButton/ShareModalContent/test.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ShareButton/ShareModalContent/test.js
@@ -25,7 +25,6 @@ describe('ShareModalContent', () => {
     expect(wrapper.find('input').props().value).toEqual('http://example.com/item/1')
     expect(wrapper.find('button').exists()).toBeTruthy()
     expect(wrapper.find('svg').exists()).toBeTruthy()
-    expect(wrapper.find('em').exists()).toBeFalsy()
   })
 
   test('onClick', () => {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ShareButton/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ShareButton/index.js
@@ -18,6 +18,7 @@ const ShareButton = ({ path }) => {
         isOpen={shareOpen}
         contentLabel='Share'
         closeFunc={() => setShareOpen(false)}
+        short
       >
         <ShareModalContent path={path} />
       </ActionModal>


### PR DESCRIPTION
I added a "short" prop to the modal which behaves similarly to "fullscreen" by altering styles. The short prop sets the height to auto instead of forcing the modal to expand based on the window height, leaving a bunch of whitespace below. It's not super elegant, but is more reusable than passing a custom style.