### PR TITLE
MARBLE-2036 INQ numbers in slug

### DIFF
--- a/@ndlib/gatsby-source-appsync-marble-inquisition/src/getItems/transform/index.js
+++ b/@ndlib/gatsby-source-appsync-marble-inquisition/src/getItems/transform/index.js
@@ -5,7 +5,7 @@ module.exports = async (appSyncItem, gatsbyInternal, pluginOptions) => {
   const { actions, createContentDigest, createNodeId } = gatsbyInternal
   const { createNode } = actions
   const { iiifRoot } = pluginOptions
-  const slug = `item/${appSyncItem.id}`
+  const slug = appSyncItem.uniqueIdentifier ? `item/${appSyncItem.uniqueIdentifier}` : `item/${appSyncItem.id}`
   const marbleObject = {
     id: createNodeId(appSyncItem.id),
     citation: citationGenerator(appSyncItem, slug),


### PR DESCRIPTION
* Use INQ number (`uniqueIdentifer`) instead of `id` for slug.
* Fallback to `id` when there is no `uniqueIdentifer`