### PR TITLE
MARBLE-2036 Use INQ numbers in urls for Inquisition

### DIFF
--- a/@ndlib/gatsby-source-appsync-marble-inquisition/src/getItems/transform/formatSearchData/index.js
+++ b/@ndlib/gatsby-source-appsync-marble-inquisition/src/getItems/transform/formatSearchData/index.js
@@ -35,7 +35,7 @@ module.exports = async (item, pluginOptions) => {
     thumbnail: getThumbnail(item),
     language: getLanguages(item),
     type: item.level,
-    url: '/item/' + item.id,
+    url: item.uniqueIdentifier ? '/item/' + item.uniqueIdentifier : '/item/' + item.id,
   }
 
   searchData.hasImages = !!searchData.thumbnail

--- a/@ndlib/gatsby-source-appsync-marble-inquisition/src/getItems/transform/index.js
+++ b/@ndlib/gatsby-source-appsync-marble-inquisition/src/getItems/transform/index.js
@@ -5,7 +5,7 @@ module.exports = async (appSyncItem, gatsbyInternal, pluginOptions) => {
   const { actions, createContentDigest, createNodeId } = gatsbyInternal
   const { createNode } = actions
   const { iiifRoot } = pluginOptions
-  const slug = `item/${appSyncItem.id}`
+  const slug = appSyncItem.uniqueIdentifier ? `item/${appSyncItem.uniqueIdentifier}` : `item/${appSyncItem.id}`
   const marbleObject = {
     id: createNodeId(appSyncItem.id),
     citation: citationGenerator(appSyncItem, slug),


### PR DESCRIPTION
* Use `uniqueIdentifier` if it exists instead of `id` for the creation of slugs
* Fallback to `id` for items without a `uniqueIdentifer`
* Update the elasticsearch `url` field to match the generated `slug`

**Example:**
https://inquisition.library.nd.edu/item/001588193 becomes https://inquisition.library.nd.edu/item/INQ-64