### PR TITLE
Fix some missing images when data is missing

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestImageGroup/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/ManifestImageGroup/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import ViewerLink from './ViewerLink'
 import ExpandIcon from './ExpandIcon'
 import ItemAlternateViews from './ItemAlternateViews'
-import { findDefaultImage } from 'utils/findImage'
+import { findImage } from 'utils/findImage'
 import { getFieldValue } from 'components/Shared/Seo/helpers.js'
 import { jsx } from 'theme-ui'
 import sx from './sx'
@@ -33,7 +33,7 @@ export const ManifestImageGroup = ({ location, marbleItem, allMarbleFile }) => {
       >
         <picture sx={sx.wrapper}>
           <img
-            src={findDefaultImage(marbleItem)}
+            src={findImage(allMarbleFile, marbleItem)}
             alt={alttext()}
             title={label}
             sx={sx.image}

--- a/@ndlib/gatsby-theme-marble/src/utils/findImage.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/findImage.js
@@ -4,7 +4,7 @@ import pdfImage from 'assets/images/pdf.svg'
 
 // eslint-disable-next-line complexity
 export const findImage = (images, marbleItem, thumbnail = false) => {
-  // try and use the default image - we should always have one, but sometimes we do not
+  // the default image if it exists
   let returnImage = findDefaultImage(marbleItem, thumbnail)
 
   // check the child images if default image returned null and was assigned a "no image" image

--- a/@ndlib/gatsby-theme-marble/src/utils/findImage.js
+++ b/@ndlib/gatsby-theme-marble/src/utils/findImage.js
@@ -4,23 +4,20 @@ import pdfImage from 'assets/images/pdf.svg'
 
 // eslint-disable-next-line complexity
 export const findImage = (images, marbleItem, thumbnail = false) => {
-  // Find the first usable image
-  const image = typy(images, 'nodes').safeArray.find(node => node.fileType === 'image') || typy(marbleItem, 'childrenMarbleFile').safeArray.find(file => file.fileType === 'image')
-  if (image && thumbnail) {
-    return typy(image, 'local.publicURL').safeString || typy(image, 'iiif.thumbnail').safeString
-  } else if (image) {
-    return typy(image, 'local.publicURL').safeString ||
-    typy(image, 'iiif.default').safeString
-  }
+  // try and use the default image - we should always have one, but sometimes we do not
+  let returnImage = findDefaultImage(marbleItem, thumbnail)
 
-  // No images were found, check to see if it is a PDF
-  const containsPDF = typy(marbleItem, 'childrenMarbleFile').safeArray.find(file => file.fileType === 'pdf')
-  if (containsPDF) {
-    return pdfImage
+  // check the child images if default image returned null and was assigned a "no image" image
+  if (returnImage === noImage || returnImage === pdfImage) {
+    const image = typy(images, 'nodes').safeArray.find(node => node.fileType === 'image') || typy(marbleItem, 'childrenMarbleFile').safeArray.find(file => file.fileType === 'image')
+    if (image && thumbnail) {
+      returnImage = typy(image, 'local.publicURL').safeString || typy(image, 'iiif.thumbnail').safeString
+    } else if (image) {
+      returnImage = typy(image, 'local.publicURL').safeString ||
+      typy(image, 'iiif.default').safeString
+    }
   }
-
-  // No image and not a pdf, return noImage icon
-  return noImage
+  return returnImage
 }
 export default findImage
 


### PR DESCRIPTION
Quick fix for missing defaultImage when image children exist.

* Fall back to looking through child images if they exist when defaultImage is null.