### PR TITLE
Fix image on search results for items with missing defaultImage

### DIFF
--- a/@ndlib/gatsby-source-appsync-marble-inquisition/src/getItems/transform/searchData/getThumbnail/index.js
+++ b/@ndlib/gatsby-source-appsync-marble-inquisition/src/getItems/transform/searchData/getThumbnail/index.js
@@ -2,7 +2,8 @@ const getIiif = require('../../getIiif')
 // eslint-disable-next-line complexity
 module.exports = (item) => {
   if (item) {
-    if (item.defaultImage) {
+    // some fields may not be null when there is no defaultImage so check the two we care about
+    if (item.defaultImage && item.defaultImage.mediaServer && item.defaultImage.mediaResourceId) {
       const iiifImage = getIiif(item.defaultImage)
       if (iiifImage) {
         return iiifImage.thumbnail

--- a/@ndlib/gatsby-source-appsync-marble/src/getItems/transform/searchData/getThumbnail/index.js
+++ b/@ndlib/gatsby-source-appsync-marble/src/getItems/transform/searchData/getThumbnail/index.js
@@ -2,7 +2,8 @@ const getIiif = require('../../getIiif')
 // eslint-disable-next-line complexity
 module.exports = (item) => {
   if (item) {
-    if (item.defaultImage) {
+    // some fields may not be null when there is no defaultImage so check the two we care about
+    if (item.defaultImage && item.defaultImage.mediaServer && item.defaultImage.mediaResourceId) {
       const iiifImage = getIiif(item.defaultImage)
       if (iiifImage) {
         return iiifImage.thumbnail


### PR DESCRIPTION
* `defaultImage` is returning a width and height for some items even when there is no mediaServer or mediaResourceId, so we need to expand the null check.
* Expand null check to specifically check for the two fields we use to build the image path.