### PR TITLE
MARBLE-1975 Fix ReturnToSearch  regression

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/DisplayCard/CardShell/LinkOrWrapper/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/DisplayCard/CardShell/LinkOrWrapper/index.js
@@ -4,12 +4,13 @@ import PropTypes from 'prop-types'
 import Link from 'components/Shared/Link'
 import sx from '../../sx.js'
 
-const LinkOrWrapper = ({ target, children }) => {
+const LinkOrWrapper = ({ target, children, referalState }) => {
   return target
     ? (
       <Link
         to={target}
         sx={sx.linkOrWrapper.link}
+        state={referalState}
       >{children}</Link>
     )
     : (
@@ -20,6 +21,7 @@ const LinkOrWrapper = ({ target, children }) => {
 LinkOrWrapper.propTypes = {
   target: PropTypes.string,
   children: PropTypes.node,
+  referalState: PropTypes.node,
 }
 
 export default LinkOrWrapper

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/DisplayCard/CardShell/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/DisplayCard/CardShell/index.js
@@ -10,10 +10,11 @@ const CardShell = ({
   controls,
   target,
   children,
+  referalState,
 }) => {
   return (
     <ThemeCard className='card' sx={sx.cardShell.themeCard}>
-      <LinkOrWrapper target={target}>
+      <LinkOrWrapper target={target} referalState={referalState}>
         {children}
         <div sx={sx.cardShell.leftBadge}>{leftBadge}</div>
         <div sx={sx.cardShell.rightBadge}>{rightBadge}</div>
@@ -29,6 +30,7 @@ CardShell.propTypes = {
   controls: PropTypes.node,
   target: PropTypes.string,
   children: PropTypes.node,
+  referalState: PropTypes.node,
 }
 
 CardShell.defaultProps = {

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/DisplayCard/MarbleItemCard/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/DisplayCard/MarbleItemCard/index.js
@@ -15,11 +15,13 @@ const MarbleItemCard = (props) => {
     collectionName,
     date,
     type,
+    referalState,
   } = props
   return (
     <DisplayCard
       title={title}
       target={target}
+      referalState={referalState}
       image={image}
       leftBadge={type === 'collection' ? <CardBadge type='collection' /> : null}
       rightBadge={<BookmarkGroup marbleItem={props} size='tiny' />}
@@ -48,10 +50,11 @@ MarbleItemCard.propTypes = {
   ]),
   collectionName: PropTypes.array,
   type: PropTypes.string,
+  referalState: PropTypes.node,
 }
 
 MarbleItemCard.defaultProps = {
-
+  referalState: {},
 }
 
 export default MarbleItemCard

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/DisplayCard/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/DisplayCard/index.js
@@ -14,6 +14,7 @@ const DisplayCard = ({
   title,
   target,
   children,
+  referalState,
 }) => {
   return (
     <CardShell
@@ -21,6 +22,7 @@ const DisplayCard = ({
       leftBadge={leftBadge}
       rightBadge={rightBadge}
       controls={controls}
+      referalState={referalState}
     >
       <figure sx={sx.displayCard.figure}>
         <CardImage image={image} alt={title} />
@@ -47,12 +49,14 @@ DisplayCard.propTypes = {
   title: PropTypes.string,
   target: PropTypes.string,
   children: PropTypes.node,
+  referalState: PropTypes.node,
 }
 
 DisplayCard.defaultProps = {
   // variant: 'default',
   leftBadge: null,
   rightBadge: null,
+  referalState: {},
 }
 
 export default DisplayCard

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchResults/HitDisplay/HitResult/index.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux'
 import BookmarkGroup from 'components/Shared/ActionButtonGroup/BookmarkGroup'
 import { isLoggedIn } from 'utils/auth'
 
+// eslint-disable-next-line complexity
 const HitResult = ({ hit, referal, loginReducer }) => {
   const {
     name,
@@ -27,7 +28,6 @@ const HitResult = ({ hit, referal, loginReducer }) => {
   } else {
     bookmark = null
   }
-
   return (
     <div sx={{ '& em': { backgroundColor: 'highlight' } }}>
       <MarbleItemCard
@@ -40,6 +40,9 @@ const HitResult = ({ hit, referal, loginReducer }) => {
         collectionName={highlightCollection(collection, hit.highlight)}
         date={date}
         type={type}
+        referalState={{
+          referal: referal,
+        }}
       >
         {
           hit.highlight && hit.highlight['identifier.idMatch']


### PR DESCRIPTION
When `Card` was refactored into `DisplayCard` and it's derivatives, state was not being passed down. This reenables this functionality.