### PR TITLE
MARBLE-2099 Make identifier search work closer to expected

### DIFF
--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchFilterBox/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchFilterBox/index.js
@@ -69,11 +69,14 @@ const customQueryBuilder = (query) => {
         {
           simple_query_string: {
             query: query,
+            analyze_wildcard: true,
+            default_operator :'AND',
             fields: [
               'name.folded^1.4',
               'creator.folded^1',
               'collection.folded^1',
               'allMetadata.folded',
+              'identifier.no_punctuation_keyword^2',
             ],
           },
         },

--- a/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchFilterBox/index.js
+++ b/@ndlib/gatsby-theme-marble/src/components/Shared/SearchTools/SearchFilterBox/index.js
@@ -76,7 +76,7 @@ const customQueryBuilder = (query) => {
               'creator.folded^1',
               'collection.folded^1',
               'allMetadata.folded',
-              'identifier.no_punctuation_keyword^2',
+              'identifier.no_punctuation_keyword^1.5',
             ],
           },
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,7 +1055,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.10.2", "@babel/core@^7.14.3", "@babel/core@^7.15.5", "@babel/core@^7.7.5":
+"@babel/core@^7.1.0", "@babel/core@^7.14.3", "@babel/core@^7.15.5", "@babel/core@^7.7.5":
   version "7.15.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.5.tgz#f8ed9ace730722544609f90c9bb49162dc3bf5b9"
   integrity sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==


### PR DESCRIPTION
This helps identifiers with hyphens like "INQ-123" work in search.