### PR TITLE
MARBLE-2132 Fix item images from getting truncated at 1000

### DIFF
--- a/@ndlib/gatsby-source-appsync-marble/src/getItems/queryItem.js
+++ b/@ndlib/gatsby-source-appsync-marble/src/getItems/queryItem.js
@@ -44,27 +44,27 @@ module.exports = (itemId, website, childrenNextToken) => {
     digitalAccess
     digitizationSource
     dimensions
-    media {
-     items {
-       id
-       mediaResourceId
-       mediaServer
-       mimeType
-       sequence
-       sourceUri
-       title
-     }
+    media(limit: 10000) {
+      items {
+        id
+        mediaResourceId
+        mediaServer
+        mimeType
+        sequence
+        sourceUri
+        title
+      }
     }
-    images {
-     items {
-       id
-       mediaResourceId
-       mediaServer
-       mimeType
-       sequence
-       sourceUri
-       title
-     }
+    images(limit: 10000) {
+      items {
+        id
+        mediaResourceId
+        mediaServer
+        mimeType
+        sequence
+        sourceUri
+        title
+      }
     }
     format
     geographicLocations {


### PR DESCRIPTION
New hard limit of 10,000 images per item (increased from default 1000).